### PR TITLE
fix: Google Ads não derruba mais a tela; Meta Ads passa a mostrar métricas de mídia

### DIFF
--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -12,8 +12,23 @@ import { EmptyState } from "./empty-state";
  * Tabela de detalhe. Também é a "table view" exigida pela acessibilidade dos
  * gráficos: todo número plotado existe aqui em texto.
  */
+/**
+ * Tabela longa empurra o resto da tela para fora da rolagem, e ninguém lê da
+ * décima linha em diante sem procurar algo específico. As demais ficam a um
+ * clique — nada é descartado.
+ */
+const LINHAS_VISIVEIS_PADRAO = 10;
+
+/**
+ * No celular cada linha vira um cartão de quatro campos, então dez linhas
+ * ocupam o que no desktop cabe em uma tabela. Cinco é o que dá para varrer sem
+ * perder o resto da página.
+ */
+const LINHAS_VISIVEIS_MOBILE = 5;
+
 export function DataTable({ block, className }: { block: TableBlock; className?: string }) {
   const [sort, setSort] = useState<{ key: string; desc: boolean } | null>(null);
+  const [expandida, setExpandida] = useState(false);
   const idOrdenacao = useId();
 
   const rows = useMemo(() => {
@@ -31,10 +46,19 @@ export function DataTable({ block, className }: { block: TableBlock; className?:
 
   // Chave estável calculada fora do JSX: a origem não garante identidade única
   // (duas campanhas podem ter o mesmo nome), então a posição desempata.
-  const keyed = useMemo(
-    () => rows.map((row, index) => ({ row, key: `${String(row[block.columns[0].key])}#${index}` })),
-    [rows, block.columns],
-  );
+  const limite = block.initialRows ?? LINHAS_VISIVEIS_PADRAO;
+  const limiteMobile = Math.min(limite, LINHAS_VISIVEIS_MOBILE);
+  const temMais = rows.length > limiteMobile;
+
+  const keyed = useMemo(() => {
+    // O recorte vem depois da ordenação: "as 10 primeiras" tem que respeitar a
+    // coluna escolhida, senão o botão mostraria um top 10 que não é top de nada.
+    const visiveis = expandida ? rows : rows.slice(0, limite);
+    return visiveis.map((row, index) => ({
+      row,
+      key: `${String(row[block.columns[0].key])}#${index}`,
+    }));
+  }, [rows, block.columns, expandida, limite]);
 
   if (block.rows.length === 0) {
     return (
@@ -110,8 +134,14 @@ export function DataTable({ block, className }: { block: TableBlock; className?:
           colunas de valor. O cartão empilha rótulo e valor, e é o que torna a
           tela útil no celular — que é onde gestor e cliente abrem o relatório. */}
       <ul aria-label={block.title} className="space-y-2 md:hidden">
-        {keyed.map(({ row, key }) => (
-          <li key={key} className="rounded-2xl border border-line bg-surface-sunken/50 p-3.5">
+        {keyed.map(({ row, key }, indice) => (
+          <li
+            key={key}
+            className={cn(
+              "rounded-2xl border border-line bg-surface-sunken/50 p-3.5",
+              !expandida && indice >= limiteMobile && "hidden",
+            )}
+          >
             <p className="text-sm font-semibold text-ink">
               {String(row[colunaPrincipal.key] ?? "—")}
             </p>
@@ -210,6 +240,30 @@ export function DataTable({ block, className }: { block: TableBlock; className?:
           </tbody>
         </table>
       </div>
+
+      {temMais ? (
+        <button
+          type="button"
+          onClick={() => setExpandida((atual) => !atual)}
+          aria-expanded={expandida}
+          className={cn(
+            "mt-3 w-full rounded-full border border-line-strong bg-surface px-4 py-2",
+            "text-xs font-medium text-ink-secondary",
+            "transition-colors duration-[var(--duration-fast)] hover:bg-surface-sunken hover:text-ink",
+            // Entre o corte do celular e o do desktop, só o celular tem o que esconder.
+            rows.length <= limite && "md:hidden",
+          )}
+        >
+          <span className="md:hidden">
+            {expandida ? `Mostrar apenas ${limiteMobile}` : `Ver todas as ${rows.length}`}
+          </span>
+          <span className="hidden md:inline">
+            {expandida
+              ? `Mostrar apenas ${limite}`
+              : `Ver todas as ${rows.length} linhas (+${rows.length - limite})`}
+          </span>
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/src/components/ui/stat-tile.tsx
+++ b/src/components/ui/stat-tile.tsx
@@ -23,7 +23,7 @@ export function StatTile({
   return (
     <div
       className={cn(
-        "group relative overflow-hidden rounded-[var(--radius-card)] border border-line bg-surface",
+        "group relative @container overflow-hidden rounded-[var(--radius-card)] border border-line bg-surface",
         "p-4 sm:p-5",
         "transition-[border-color,box-shadow] duration-[var(--duration-base)] ease-[var(--ease-out-soft)]",
         "hover:border-line-strong hover:shadow-[0_8px_28px_-20px_rgba(47,37,53,0.4)]",
@@ -51,12 +51,14 @@ export function StatTile({
         ) : null}
       </div>
 
-      {/* O valor escala com o container: moeda longa (R$ 1.234.567,89) não pode
-          estourar a borda nem quebrar em duas linhas dentro do tile. */}
+      {/* O valor escala com a largura do próprio tile (`cqw`), não com a da
+          janela. Com `vw` a fonte ignorava quantos KPIs dividem a linha: nove
+          indicadores em 1440px estreitam o tile, e "R$ 18.783,83" era cortado
+          pelo `overflow-hidden` acima. */}
       <p
         className={cn(
           "mt-3 font-semibold tracking-tight text-ink",
-          emphasis ? "text-[clamp(1.5rem,2.4vw,2.25rem)]" : "text-[clamp(1.25rem,1.6vw,1.5rem)]",
+          emphasis ? "text-[clamp(1.25rem,11cqw,2.25rem)]" : "text-[clamp(1.125rem,9cqw,1.5rem)]",
         )}
       >
         {formatMetric(kpi.value, kpi.format)}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,6 +68,12 @@ export interface TableBlock {
   description?: string;
   columns: TableColumn[];
   rows: Array<Record<string, string | number>>;
+  /**
+   * Quantas linhas aparecem antes do "Ver todas". Uma tabela de 34 palavras-chave
+   * empurra o resto da tela para fora da rolagem e ninguém lê da décima em
+   * diante — mas o dado continua a um clique. Padrão: `LINHAS_VISIVEIS_PADRAO`.
+   */
+  initialRows?: number;
 }
 
 export interface ChannelReport {

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -27,22 +27,28 @@ export function mockMetaAds(range: DateRange, fetchedAt = NOW): ChannelReport {
     const spend = dailyValue("meta:spend", date, 640);
     const impressions = dailyValue("meta:impr", date, 78_000);
     const clicks = dailyValue("meta:clicks", date, 1_240);
+    const linkClicks = dailyValue("meta:linkclicks", date, 520);
     const leads = dailyValue("meta:leads", date, 34);
     return {
       date,
       spend: Math.round(spend * 100) / 100,
       impressions: Math.round(impressions),
       clicks: Math.round(clicks),
+      linkClicks: Math.round(linkClicks),
       leads: Math.round(leads),
       ctr: safeDiv(clicks, impressions),
+      cpm: safeDiv(spend, impressions) * 1000,
       cpl: safeDiv(spend, Math.max(1, Math.round(leads))),
     };
   });
 
   const spend = sum(series, "spend");
   const clicks = sum(series, "clicks");
+  const linkClicks = sum(series, "linkClicks");
   const impressions = sum(series, "impressions");
   const leads = sum(series, "leads");
+  // Frequência ~2,4: alcance é uma fração das impressões, não a soma dos dias.
+  const reach = Math.round(impressions / 2.4);
 
   return {
     channel: "meta-ads",
@@ -57,6 +63,54 @@ export function mockMetaAds(range: DateRange, fetchedAt = NOW): ChannelReport {
         value: spend,
         previousValue: spend * 0.91,
         format: "currency",
+      },
+      {
+        key: "impressions",
+        label: "Impressões",
+        value: impressions,
+        previousValue: impressions * 0.88,
+        format: "integer",
+      },
+      {
+        key: "reach",
+        label: "Alcance",
+        value: reach,
+        previousValue: reach * 0.9,
+        format: "integer",
+        hint: "Pessoas distintas que viram os anúncios.",
+      },
+      {
+        key: "cpm",
+        label: "CPM",
+        value: safeDiv(spend, impressions) * 1000,
+        previousValue: safeDiv(spend * 0.91, impressions * 0.88) * 1000,
+        format: "currency",
+        lowerIsBetter: true,
+        hint: "Custo por mil impressões, calculado sobre o total do período.",
+      },
+      {
+        key: "ctr",
+        label: "CTR",
+        value: safeDiv(clicks, impressions),
+        previousValue: safeDiv(clicks, impressions) * 0.96,
+        format: "percent",
+      },
+      {
+        key: "frequency",
+        label: "Frequência",
+        value: safeDiv(impressions, reach),
+        previousValue: safeDiv(impressions, reach) * 0.94,
+        format: "decimal",
+        lowerIsBetter: true,
+        hint: "Quantas vezes, em média, cada pessoa alcançada viu um anúncio.",
+      },
+      {
+        key: "linkClicks",
+        label: "Cliques no link",
+        value: linkClicks,
+        previousValue: linkClicks * 0.93,
+        format: "integer",
+        hint: "Só cliques que levaram ao destino.",
       },
       {
         key: "leads",
@@ -74,25 +128,13 @@ export function mockMetaAds(range: DateRange, fetchedAt = NOW): ChannelReport {
         lowerIsBetter: true,
         hint: "Investimento dividido pelos leads do período.",
       },
-      {
-        key: "ctr",
-        label: "CTR",
-        value: safeDiv(clicks, impressions),
-        previousValue: safeDiv(clicks, impressions) * 0.96,
-        format: "percent",
-      },
-      {
-        key: "clicks",
-        label: "Cliques",
-        value: clicks,
-        previousValue: clicks * 0.93,
-        format: "integer",
-      },
     ],
     series,
     seriesDefs: [
       { key: "spend", label: "Investimento", format: "currency", slot: 1 },
       { key: "leads", label: "Leads", format: "integer", slot: 2 },
+      { key: "impressions", label: "Impressões", format: "integer", slot: 3 },
+      { key: "cpm", label: "CPM", format: "currency", slot: 4 },
     ],
     tables: [
       {
@@ -101,9 +143,12 @@ export function mockMetaAds(range: DateRange, fetchedAt = NOW): ChannelReport {
         columns: [
           { key: "name", label: "Campanha", align: "left" },
           { key: "spend", label: "Investimento", format: "currency", align: "right" },
+          { key: "impressions", label: "Impressões", format: "integer", align: "right" },
+          { key: "cpm", label: "CPM", format: "currency", align: "right" },
+          { key: "ctr", label: "CTR", format: "percent", align: "right" },
+          { key: "linkClicks", label: "Cliques no link", format: "integer", align: "right" },
           { key: "leads", label: "Leads", format: "integer", align: "right" },
           { key: "cpl", label: "CPL", format: "currency", align: "right" },
-          { key: "ctr", label: "CTR", format: "percent", align: "right" },
         ],
         rows: [
           "Conversão | Emagrecimento | Broad",
@@ -112,39 +157,48 @@ export function mockMetaAds(range: DateRange, fetchedAt = NOW): ChannelReport {
           "Conversão | Check-up | Interesses saúde",
           "Reconhecimento | Marca | Vídeo 15s",
         ].map((name, i) => {
-          const s = spend * [0.34, 0.26, 0.17, 0.14, 0.09][i];
+          const fatia = [0.34, 0.26, 0.17, 0.14, 0.09][i];
+          const s = spend * fatia;
+          // A fatia de impressões difere da de investimento de propósito: com a
+          // mesma fatia nos dois, o CPM sai idêntico em toda campanha e a
+          // coluna parece quebrada.
+          const impr = Math.round(impressions * [0.29, 0.24, 0.22, 0.13, 0.12][i]);
           const l = Math.round(leads * [0.38, 0.29, 0.12, 0.16, 0.05][i]);
           return {
             name,
             spend: Math.round(s * 100) / 100,
+            impressions: impr,
+            cpm: Math.round(safeDiv(s, impr) * 1000 * 100) / 100,
+            ctr: 0.009 + noise(`meta-ctr-campanha-${i}-${name.length}`) * 0.026,
+            linkClicks: Math.round(linkClicks * fatia),
             leads: l,
             cpl: Math.round(safeDiv(s, l) * 100) / 100,
-            ctr: 0.009 + noise(`meta-ctr-campanha-${i}-${name.length}`) * 0.026,
           };
         }),
       },
       {
-        title: "Origem das conversões",
+        title: "Retenção de vídeo",
         description:
-          "Toda ação registrada no período, e quais delas o painel conta como lead. A Meta credita uma conversão a qualquer anúncio que a pessoa clicou nos últimos 7 dias ou viu no último dia — inclusive campanhas de topo de funil.",
+          "Quantas pessoas seguiram assistindo até cada marca. A porcentagem é sobre quem começou a assistir, que é a base usada pela própria Meta.",
         columns: [
-          { key: "acao", label: "Ação", align: "left" },
-          { key: "identificador", label: "Identificador na Meta", align: "left" },
-          { key: "quantidade", label: "Quantidade", format: "integer", align: "right" },
-          { key: "contaComoLead", label: "Conta como lead", align: "right" },
+          { key: "etapa", label: "Etapa", align: "left" },
+          { key: "pessoas", label: "Pessoas", format: "integer", align: "right" },
+          { key: "retencao", label: "% de quem começou", format: "percent", align: "right" },
         ],
-        rows: [
-          ["Lead pelo pixel do site", "offsite_conversion.fb_pixel_lead", 0.72, "sim"],
-          ["Visualização da página de destino", "landing_page_view", 12.4, "não"],
-          ["Clique no link", "link_click", 26.8, "não"],
-          ["Engajamento com a publicação", "post_engagement", 41.2, "não"],
-          ["Lead por formulário instantâneo", "onsite_conversion.lead_grouped", 0.28, "sim"],
-        ].map(([acao, identificador, fator, contaComoLead]) => ({
-          acao: acao as string,
-          identificador: identificador as string,
-          quantidade: Math.round(leads * (fator as number)),
-          contaComoLead: contaComoLead as string,
-        })),
+        rows: (() => {
+          const reproducoes = Math.round(impressions * 0.31);
+          return [
+            ["Começou a assistir", 1],
+            ["Assistiu 25%", 0.47],
+            ["Assistiu 50%", 0.28],
+            ["Assistiu 75%", 0.19],
+            ["Assistiu até o fim", 0.13],
+          ].map(([etapa, fator]) => ({
+            etapa: etapa as string,
+            pessoas: Math.round(reproducoes * (fator as number)),
+            retencao: fator as number,
+          }));
+        })(),
       },
     ],
     notices: [],

--- a/src/server/connectors/google-ads.ts
+++ b/src/server/connectors/google-ads.ts
@@ -5,7 +5,7 @@ import type { ChannelReport, DateRange, SeriesPoint } from "@/lib/types";
 import { mockGoogleAds } from "@/mocks/reports";
 import { getCredentials, getEnv, isForceMock } from "@/server/env";
 import { getGoogleAccessToken } from "@/server/lib/google-auth";
-import { type HttpError, httpJson } from "@/server/lib/http";
+import { type HttpError, httpJson, redactSecrets } from "@/server/lib/http";
 import { buildGoogleAdsSnapshotReport } from "./google-ads-snapshot";
 
 /**
@@ -70,6 +70,17 @@ function ehTokenAguardandoAprovacao(erro: unknown): boolean {
   return /DEVELOPER_TOKEN_NOT_APPROVED|DEVELOPER_TOKEN_PROHIBITED/i.test(texto);
 }
 
+/**
+ * Resumo curto do erro para o aviso na tela. Passa pelo `redactSecrets` porque
+ * a resposta da Google costuma ecoar a requisição, e a requisição leva token.
+ */
+function descreverFalha(erro: unknown): string {
+  const bruto = erro instanceof Error ? erro.message : String(erro);
+  const corpo = (erro as HttpError)?.body;
+  const texto = redactSecrets(typeof corpo === "string" && corpo ? `${bruto} — ${corpo}` : bruto);
+  return texto.length > 240 ? `${texto.slice(0, 240)}…` : texto;
+}
+
 export async function fetchGoogleAdsReport(range: DateRange): Promise<ChannelReport> {
   const forceMock = isForceMock();
 
@@ -104,11 +115,14 @@ export async function fetchGoogleAdsReport(range: DateRange): Promise<ChannelRep
       ),
     ]);
   } catch (erro) {
-    if (!ehTokenAguardandoAprovacao(erro)) throw erro;
-
+    // Este canal tem o export da plataforma como piso: dado real da conta, já
+    // conferido. Derrubar a tela por erro de API seria trocar dado bom por
+    // nenhum dado — e é numa reunião que a tela costuma ser aberta.
     const report = buildGoogleAdsSnapshotReport(range);
     report.notices = [
-      "O token de desenvolvedor do Google Ads ainda está com acesso de teste, que não lê contas de produção. Solicite o acesso básico na Central de API da conta gerente — o token não muda, só o nível de acesso.",
+      ehTokenAguardandoAprovacao(erro)
+        ? "O token de desenvolvedor do Google Ads ainda está com acesso de teste, que não lê contas de produção. Solicite o acesso básico na Central de API da conta gerente — o token não muda, só o nível de acesso."
+        : `A API do Google Ads não respondeu, então os números abaixo vêm do export da plataforma. Detalhe técnico: ${descreverFalha(erro)}`,
       ...report.notices,
     ];
     return report;

--- a/src/server/connectors/meta-ads.ts
+++ b/src/server/connectors/meta-ads.ts
@@ -11,13 +11,26 @@ import { httpJson, metaAuthHeaders } from "@/server/lib/http";
  * Docs: https://developers.facebook.com/docs/marketing-api/insights
  */
 
+/** `{action_type, value}` — o formato que a Insights usa para toda métrica de ação. */
+type AcoesDaMeta = Array<{ action_type: string; value: string }>;
+
 interface MetaInsightsRow {
   date_start: string;
   spend?: string;
   impressions?: string;
+  /** Pessoas distintas alcançadas. Não é aditivo entre dias. */
+  reach?: string;
   clicks?: string;
+  /** Cliques no link do anúncio, sem contar clique em curtida, comentário etc. */
+  inline_link_clicks?: string;
   ctr?: string;
-  actions?: Array<{ action_type: string; value: string }>;
+  actions?: AcoesDaMeta;
+  /** Reproduções de vídeo — a base de retenção que a própria Meta usa. */
+  video_play_actions?: AcoesDaMeta;
+  video_p25_watched_actions?: AcoesDaMeta;
+  video_p50_watched_actions?: AcoesDaMeta;
+  video_p75_watched_actions?: AcoesDaMeta;
+  video_p100_watched_actions?: AcoesDaMeta;
   campaign_name?: string;
 }
 
@@ -36,39 +49,6 @@ const DETAILED_LEAD_ACTIONS = new Set([
   "offsite_conversion.fb_pixel_lead",
   "onsite_conversion.lead_grouped",
 ]);
-
-/** Todos os tipos que representam lead, para rotular a tabela de origem. */
-const LEAD_ACTIONS = new Set(["lead", ...DETAILED_LEAD_ACTIONS]);
-
-/**
- * Nome legível dos tipos de ação mais comuns.
- *
- * A Meta devolve identificadores técnicos (`offsite_conversion.fb_pixel_lead`)
- * que não dizem nada a quem opera a conta. Traduzir aqui é o que permite
- * responder à pergunta que sempre aparece: "de onde saiu esse lead, se não
- * tenho campanha de lead rodando?".
- */
-const ROTULO_DA_ACAO: Record<string, string> = {
-  lead: "Lead (genérico)",
-  "offsite_conversion.fb_pixel_lead": "Lead pelo pixel do site",
-  "onsite_conversion.lead_grouped": "Lead por formulário instantâneo",
-  "onsite_conversion.messaging_conversation_started_7d": "Conversa iniciada",
-  complete_registration: "Cadastro concluído",
-  "offsite_conversion.fb_pixel_complete_registration": "Cadastro pelo pixel",
-  contact: "Contato",
-  "offsite_conversion.fb_pixel_custom": "Conversão personalizada",
-  purchase: "Compra",
-  "offsite_conversion.fb_pixel_purchase": "Compra pelo pixel",
-  landing_page_view: "Visualização da página de destino",
-  link_click: "Clique no link",
-  post_engagement: "Engajamento com a publicação",
-  page_engagement: "Engajamento com a página",
-  video_view: "Visualização de vídeo",
-};
-
-function rotularAcao(tipo: string): string {
-  return ROTULO_DA_ACAO[tipo] ?? tipo;
-}
 
 /**
  * Conta os leads de uma linha de insights.
@@ -128,6 +108,31 @@ async function fetchInsights(
   return rows;
 }
 
+/**
+ * `cpm` e `frequency` não são pedidos: a Meta os devolve por linha, e somar
+ * média de dia com média de dia dá número errado. Ambos são recalculados dos
+ * totais — CPM sobre impressões, frequência sobre alcance.
+ */
+const CAMPOS_DE_METRICA = [
+  "spend",
+  "impressions",
+  "reach",
+  "clicks",
+  "inline_link_clicks",
+  "ctr",
+  "actions",
+  "video_play_actions",
+  "video_p25_watched_actions",
+  "video_p50_watched_actions",
+  "video_p75_watched_actions",
+  "video_p100_watched_actions",
+].join(",");
+
+/** Soma uma métrica de ação da Meta, que sempre vem como lista de pares. */
+function somarAcoes(acoes: AcoesDaMeta | undefined): number {
+  return (acoes ?? []).reduce((total, item) => total + num(item.value), 0);
+}
+
 export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelReport> {
   const forceMock = isForceMock();
 
@@ -143,12 +148,12 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
 
   const [daily, byCampaign] = await Promise.all([
     fetchInsights(range, {
-      fields: "spend,impressions,clicks,ctr,actions",
+      fields: CAMPOS_DE_METRICA,
       time_increment: "1",
       level: "account",
     }),
     fetchInsights(range, {
-      fields: "campaign_name,spend,impressions,clicks,ctr,actions",
+      fields: `campaign_name,${CAMPOS_DE_METRICA}`,
       level: "campaign",
     }),
   ]);
@@ -160,14 +165,17 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
     const spend = num(row?.spend);
     const impressions = num(row?.impressions);
     const clicks = num(row?.clicks);
+    const linkClicks = num(row?.inline_link_clicks);
     const leads = row ? countLeads(row) : 0;
     return {
       date,
       spend,
       impressions,
       clicks,
+      linkClicks,
       leads,
       ctr: impressions === 0 ? 0 : clicks / impressions,
+      cpm: impressions === 0 ? 0 : (spend / impressions) * 1000,
       cpl: leads === 0 ? 0 : spend / leads,
     };
   });
@@ -177,40 +185,25 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
       spend: acc.spend + Number(p.spend),
       impressions: acc.impressions + Number(p.impressions),
       clicks: acc.clicks + Number(p.clicks),
+      linkClicks: acc.linkClicks + Number(p.linkClicks),
       leads: acc.leads + Number(p.leads),
     }),
-    { spend: 0, impressions: 0, clicks: 0, leads: 0 },
+    { spend: 0, impressions: 0, clicks: 0, linkClicks: 0, leads: 0 },
   );
 
-  // De onde vêm as conversões: a Meta credita uma conversão a qualquer anúncio
-  // que a pessoa clicou (7 dias) ou viu (1 dia) antes de converter — inclusive
-  // campanha de topo de funil, cujo objetivo não é lead. Sem esta tabela, o
-  // número de leads aparece sem explicação para quem opera a conta.
-  const porTipoDeAcao = new Map<string, number>();
-  for (const row of daily) {
-    for (const acao of row.actions ?? []) {
-      const valor = Number(acao.value || 0);
-      if (!Number.isFinite(valor) || valor === 0) continue;
-      porTipoDeAcao.set(acao.action_type, (porTipoDeAcao.get(acao.action_type) ?? 0) + valor);
-    }
-  }
+  // Alcance conta pessoas distintas: somar os dias contaria de novo quem voltou.
+  // O valor do período só existe numa consulta sem `time_increment`, que é a de
+  // campanha — e mesmo ela só é somável porque uma pessoa alcançada por duas
+  // campanhas é rara o bastante para o número seguir útil. O rótulo avisa.
+  const alcance = byCampaign.reduce((total, row) => total + num(row.reach), 0);
 
-  // Quando a Meta devolve o tipo agregado, os detalhados já estão dentro dele —
-  // a tabela precisa dizer isso, senão os números não fecham com o KPI.
-  const temAgregado = porTipoDeAcao.has("lead");
-
-  const origemDasAcoes = [...porTipoDeAcao.entries()]
-    .map(([tipo, quantidade]) => ({
-      acao: rotularAcao(tipo),
-      identificador: tipo,
-      quantidade,
-      contaComoLead: !LEAD_ACTIONS.has(tipo)
-        ? "não"
-        : temAgregado && tipo !== "lead"
-          ? "já incluído em Lead"
-          : "sim",
-    }))
-    .sort((a, b) => b.quantidade - a.quantidade);
+  const video = {
+    reproducoes: byCampaign.reduce((t, r) => t + somarAcoes(r.video_play_actions), 0),
+    p25: byCampaign.reduce((t, r) => t + somarAcoes(r.video_p25_watched_actions), 0),
+    p50: byCampaign.reduce((t, r) => t + somarAcoes(r.video_p50_watched_actions), 0),
+    p75: byCampaign.reduce((t, r) => t + somarAcoes(r.video_p75_watched_actions), 0),
+    p100: byCampaign.reduce((t, r) => t + somarAcoes(r.video_p100_watched_actions), 0),
+  };
 
   return {
     channel: "meta-ads",
@@ -220,12 +213,49 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
     fetchedAt: new Date().toISOString(),
     kpis: [
       { key: "spend", label: "Investimento", value: totals.spend, format: "currency" },
+      { key: "impressions", label: "Impressões", value: totals.impressions, format: "integer" },
+      {
+        key: "reach",
+        label: "Alcance",
+        value: alcance,
+        format: "integer",
+        hint: "Pessoas distintas que viram os anúncios. Somado entre campanhas, então quem foi alcançado por mais de uma campanha aparece mais de uma vez.",
+      },
+      {
+        key: "cpm",
+        label: "CPM",
+        value: totals.impressions === 0 ? 0 : (totals.spend / totals.impressions) * 1000,
+        format: "currency",
+        lowerIsBetter: true,
+        hint: "Custo por mil impressões, calculado sobre o total do período — não é a média das médias diárias.",
+      },
+      {
+        key: "ctr",
+        label: "CTR",
+        value: totals.impressions === 0 ? 0 : totals.clicks / totals.impressions,
+        format: "percent",
+      },
+      {
+        key: "frequency",
+        label: "Frequência",
+        value: alcance === 0 ? 0 : totals.impressions / alcance,
+        format: "decimal",
+        lowerIsBetter: true,
+        hint: "Quantas vezes, em média, cada pessoa alcançada viu um anúncio.",
+      },
+      {
+        key: "linkClicks",
+        label: "Cliques no link",
+        value: totals.linkClicks,
+        format: "integer",
+        hint: "Só cliques que levaram ao destino. O total de cliques inclui curtida, comentário e expansão de imagem.",
+      },
       {
         key: "leads",
         label: "Leads",
         value: totals.leads,
         format: "integer",
-        hint: "Conversões que a Meta atribuiu aos anúncios do período. A atribuição padrão é de 7 dias por clique e 1 dia por visualização, então campanhas de topo e meio de funil também recebem crédito. A tabela \u0022Origem das conversões\u0022 mostra a composição.",
+        hint: "Conversões que a Meta atribuiu aos anúncios do período. A atribuição padrão é de 7 dias por clique e 1 dia por visualização, então campanhas de topo e meio de funil também recebem crédito.",
       },
       {
         key: "cpl",
@@ -234,18 +264,13 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
         format: "currency",
         lowerIsBetter: true,
       },
-      {
-        key: "ctr",
-        label: "CTR",
-        value: totals.impressions === 0 ? 0 : totals.clicks / totals.impressions,
-        format: "percent",
-      },
-      { key: "clicks", label: "Cliques", value: totals.clicks, format: "integer" },
     ],
     series,
     seriesDefs: [
       { key: "spend", label: "Investimento", format: "currency", slot: 1 },
       { key: "leads", label: "Leads", format: "integer", slot: 2 },
+      { key: "impressions", label: "Impressões", format: "integer", slot: 3 },
+      { key: "cpm", label: "CPM", format: "currency", slot: 4 },
     ],
     tables: [
       {
@@ -254,9 +279,12 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
         columns: [
           { key: "name", label: "Campanha", align: "left" },
           { key: "spend", label: "Investimento", format: "currency", align: "right" },
+          { key: "impressions", label: "Impressões", format: "integer", align: "right" },
+          { key: "cpm", label: "CPM", format: "currency", align: "right" },
+          { key: "ctr", label: "CTR", format: "percent", align: "right" },
+          { key: "linkClicks", label: "Cliques no link", format: "integer", align: "right" },
           { key: "leads", label: "Leads", format: "integer", align: "right" },
           { key: "cpl", label: "CPL", format: "currency", align: "right" },
-          { key: "ctr", label: "CTR", format: "percent", align: "right" },
         ],
         rows: byCampaign
           .map((row) => {
@@ -267,26 +295,65 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
             return {
               name: row.campaign_name ?? "—",
               spend,
+              impressions,
+              cpm: impressions === 0 ? 0 : (spend / impressions) * 1000,
+              ctr: impressions === 0 ? 0 : clicks / impressions,
+              linkClicks: num(row.inline_link_clicks),
               leads,
               cpl: leads === 0 ? 0 : spend / leads,
-              ctr: impressions === 0 ? 0 : clicks / impressions,
             };
           })
-          .sort((a, b) => b.spend - a.spend)
-          .slice(0, 25),
+          .sort((a, b) => b.spend - a.spend),
       },
-      {
-        title: "Origem das conversões",
-        description:
-          "Toda ação registrada no período, e quais delas o painel conta como lead. A Meta credita uma conversão a qualquer anúncio que a pessoa clicou nos últimos 7 dias ou viu no último dia — inclusive campanhas de topo de funil.",
-        columns: [
-          { key: "acao", label: "Ação", align: "left" },
-          { key: "identificador", label: "Identificador na Meta", align: "left" },
-          { key: "quantidade", label: "Quantidade", format: "integer", align: "right" },
-          { key: "contaComoLead", label: "Conta como lead", align: "right" },
-        ],
-        rows: origemDasAcoes,
-      },
+      // Só entra quando existe vídeo na conta: uma tabela de zeros ocupa espaço
+      // e sugere que a campanha performou mal, quando ela nem é de vídeo.
+      ...(video.reproducoes > 0
+        ? [
+            {
+              title: "Retenção de vídeo",
+              description:
+                "Quantas pessoas seguiram assistindo até cada marca. A porcentagem é sobre quem começou a assistir, que é a base usada pela própria Meta.",
+              columns: [
+                { key: "etapa", label: "Etapa", align: "left" as const },
+                {
+                  key: "pessoas",
+                  label: "Pessoas",
+                  format: "integer" as const,
+                  align: "right" as const,
+                },
+                {
+                  key: "retencao",
+                  label: "% de quem começou",
+                  format: "percent" as const,
+                  align: "right" as const,
+                },
+              ],
+              rows: [
+                { etapa: "Começou a assistir", pessoas: video.reproducoes, retencao: 1 },
+                {
+                  etapa: "Assistiu 25%",
+                  pessoas: video.p25,
+                  retencao: video.p25 / video.reproducoes,
+                },
+                {
+                  etapa: "Assistiu 50%",
+                  pessoas: video.p50,
+                  retencao: video.p50 / video.reproducoes,
+                },
+                {
+                  etapa: "Assistiu 75%",
+                  pessoas: video.p75,
+                  retencao: video.p75 / video.reproducoes,
+                },
+                {
+                  etapa: "Assistiu até o fim",
+                  pessoas: video.p100,
+                  retencao: video.p100 / video.reproducoes,
+                },
+              ],
+            },
+          ]
+        : []),
     ],
     notices: [],
   };

--- a/tests/integration/connectors.test.ts
+++ b/tests/integration/connectors.test.ts
@@ -132,16 +132,61 @@ describe("Meta Ads", () => {
     expect(report.kpis.find((k) => k.key === "leads")?.value).toBe(10);
   });
 
-  it("marca na tabela de origem que o detalhado já está dentro do agregado", async () => {
+  it("calcula CPM, frequência e cliques no link a partir dos totais", async () => {
+    await withCredentials({ META_ACCESS_TOKEN: "t", META_AD_ACCOUNT_ID: "123" });
+    mockFetch((url) =>
+      url.includes("level=campaign")
+        ? {
+            data: [
+              {
+                date_start: "2026-02-01",
+                campaign_name: "Conversão | Teste",
+                spend: "300.00",
+                impressions: "100000",
+                reach: "40000",
+                clicks: "900",
+                inline_link_clicks: "500",
+              },
+            ],
+          }
+        : {
+            data: [
+              {
+                date_start: "2026-02-01",
+                spend: "300.00",
+                impressions: "100000",
+                clicks: "900",
+                inline_link_clicks: "500",
+              },
+            ],
+          },
+    );
+
+    const { fetchMetaAdsReport } = await import("@/server/connectors/meta-ads");
+    const report = await fetchMetaAdsReport(RANGE);
+    const kpi = (key: string) => report.kpis.find((k) => k.key === key)?.value;
+
+    // CPM sobre o total, não média das médias diárias: 300 / 100000 * 1000.
+    expect(kpi("cpm")).toBeCloseTo(3, 5);
+    // Frequência é impressões por pessoa alcançada: 100000 / 40000.
+    expect(kpi("frequency")).toBeCloseTo(2.5, 5);
+    // Cliques no link não é o total de cliques — o total inclui curtida e afins.
+    expect(kpi("linkClicks")).toBe(500);
+    expect(kpi("clicks" as string) ?? 900).not.toBe(kpi("linkClicks"));
+    expect(kpi("reach")).toBe(40000);
+  });
+
+  it("não expõe identificador cru da API na tela", async () => {
     await withCredentials({ META_ACCESS_TOKEN: "t", META_AD_ACCOUNT_ID: "123" });
     mockFetch(() => ({
       data: [
         {
           date_start: "2026-02-01",
           spend: "100.00",
+          impressions: "1000",
           actions: [
             { action_type: "lead", value: "10" },
-            { action_type: "offsite_conversion.fb_pixel_lead", value: "10" },
+            { action_type: "onsite_conversion.post_net_like", value: "339" },
           ],
         },
       ],
@@ -150,15 +195,58 @@ describe("Meta Ads", () => {
     const { fetchMetaAdsReport } = await import("@/server/connectors/meta-ads");
     const report = await fetchMetaAdsReport(RANGE);
 
-    const origem = report.tables.find((t) => t.title === "Origem das conversões");
-    const agregado = origem?.rows.find((r) => r.identificador === "lead");
-    const detalhado = origem?.rows.find(
-      (r) => r.identificador === "offsite_conversion.fb_pixel_lead",
+    // `onsite_conversion.post_net_like` e afins são nomes internos da Meta.
+    // Já foram parar na tela de cliente uma vez; não podem voltar.
+    const tudo = JSON.stringify(report.tables);
+    expect(tudo).not.toMatch(/onsite_conversion|post_interaction|omni_/);
+  });
+
+  it("mostra retenção de vídeo, e só quando há vídeo", async () => {
+    await withCredentials({ META_ACCESS_TOKEN: "t", META_AD_ACCOUNT_ID: "123" });
+    mockFetch((url) =>
+      url.includes("level=campaign")
+        ? {
+            data: [
+              {
+                date_start: "2026-02-01",
+                campaign_name: "Vídeo | Teste",
+                spend: "100.00",
+                impressions: "1000",
+                video_play_actions: [{ action_type: "video_view", value: "800" }],
+                video_p25_watched_actions: [{ action_type: "video_view", value: "400" }],
+                video_p50_watched_actions: [{ action_type: "video_view", value: "200" }],
+                video_p75_watched_actions: [{ action_type: "video_view", value: "100" }],
+                video_p100_watched_actions: [{ action_type: "video_view", value: "40" }],
+              },
+            ],
+          }
+        : { data: [{ date_start: "2026-02-01", spend: "100.00", impressions: "1000" }] },
     );
 
-    expect(agregado?.contaComoLead).toBe("sim");
-    // Sem esta marcação, a tabela some 10 + 10 aos olhos de quem confere o KPI.
-    expect(detalhado?.contaComoLead).toBe("já incluído em Lead");
+    const { fetchMetaAdsReport } = await import("@/server/connectors/meta-ads");
+    const report = await fetchMetaAdsReport(RANGE);
+    const video = report.tables.find((t) => t.title === "Retenção de vídeo");
+
+    expect(video).toBeDefined();
+    // A porcentagem é sobre quem começou, que é a base da própria Meta.
+    expect(video?.rows.find((r) => r.etapa === "Assistiu 50%")?.retencao).toBeCloseTo(0.25, 5);
+    expect(video?.rows.find((r) => r.etapa === "Assistiu até o fim")?.retencao).toBeCloseTo(
+      0.05,
+      5,
+    );
+  });
+
+  it("omite a tabela de vídeo quando a conta não tem vídeo", async () => {
+    await withCredentials({ META_ACCESS_TOKEN: "t", META_AD_ACCOUNT_ID: "123" });
+    mockFetch(() => ({
+      data: [{ date_start: "2026-02-01", spend: "100.00", impressions: "1000" }],
+    }));
+
+    const { fetchMetaAdsReport } = await import("@/server/connectors/meta-ads");
+    const report = await fetchMetaAdsReport(RANGE);
+
+    // Tabela de zeros ocupa espaço e sugere campanha ruim, quando nem é de vídeo.
+    expect(report.tables.find((t) => t.title === "Retenção de vídeo")).toBeUndefined();
   });
 
   it("preenche com zero os dias sem entrega, para o eixo não pular", async () => {

--- a/tests/integration/connectors.test.ts
+++ b/tests/integration/connectors.test.ts
@@ -396,7 +396,7 @@ describe("Google Ads — token aguardando aprovação", () => {
     expect(report.series.length).toBeGreaterThan(0);
   });
 
-  it("propaga erro que não seja de aprovação — falha real não vira demonstração", async () => {
+  it("falha genérica da API também cai no snapshot, mas o aviso diz o que houve", async () => {
     await withCredentials({
       ...GOOGLE_OAUTH,
       GOOGLE_ADS_DEVELOPER_TOKEN: "dev",
@@ -422,6 +422,57 @@ describe("Google Ads — token aguardando aprovação", () => {
     );
 
     const { fetchGoogleAdsReport } = await import("@/server/connectors/google-ads");
-    await expect(fetchGoogleAdsReport(RANGE)).rejects.toThrow();
+    const report = await fetchGoogleAdsReport(RANGE);
+
+    // Este canal tem export conferido da plataforma como piso. Derrubar a tela
+    // por erro de API trocaria dado real por nenhum dado — e foi exatamente o
+    // que aconteceu em produção: `/google-ads` virou "não foi possível
+    // carregar" com o snapshot pronto e sem uso.
+    expect(report.source).toBe("snapshot");
+    expect(report.kpis.length).toBeGreaterThan(0);
+
+    // O piso não pode virar disfarce: a falha precisa aparecer na tela.
+    expect(report.notices[0]).toMatch(/não respondeu/i);
+    expect(report.notices[0]).toMatch(/Customer not found/);
+    expect(report.notices[0]).not.toMatch(/acesso de teste/i);
+  });
+
+  it("não vaza segredo no aviso de falha", async () => {
+    await withCredentials({
+      ...GOOGLE_OAUTH,
+      GOOGLE_ADS_DEVELOPER_TOKEN: "dev",
+      GOOGLE_ADS_CUSTOMER_ID: "123-456-7890",
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("oauth2.googleapis.com")) {
+          return new Response(JSON.stringify(TOKEN_RESPONSE), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        // A Google ecoa a requisição no erro, e a requisição leva credencial.
+        return new Response(
+          JSON.stringify({
+            error: { message: "Bad request: developer-token=segredo-do-cliente" },
+          }),
+          {
+            status: 400,
+            statusText: "Bad Request",
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }),
+    );
+
+    const { fetchGoogleAdsReport } = await import("@/server/connectors/google-ads");
+    const report = await fetchGoogleAdsReport(RANGE);
+
+    expect(report.source).toBe("snapshot");
+    expect(report.notices[0]).not.toMatch(/segredo-do-cliente/);
+    expect(report.notices[0]).toMatch(/oculto/);
   });
 });


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia: os três problemas vieram de uso real da tela em produção,
não de backlog. Abro as Issues correspondentes referenciando este PR.

## O que mudou

### 1. `/google-ads` estava morto em produção

A página mostrava "Não foi possível carregar os dados" com o snapshot da
plataforma pronto e sem uso.

O fallback só cobria dois casos: sem credencial, ou `DEVELOPER_TOKEN_NOT_APPROVED`.
Com o token cadastrado e a API respondendo qualquer outro erro, o conector
relançava e a página morria.

A decisão anterior — "falha real não vira demonstração" — está certa para um
canal sem dado próprio. Não vale aqui: este canal tem export conferido da
plataforma como piso, e trocar dado real por tela morta é pior em qualquer
cenário. Agora qualquer falha cai no snapshot.

O piso não vira disfarce: o aviso na tela diz o que houve, com o detalhe
técnico passando por `redactSecrets` — a Google ecoa a requisição no erro, e a
requisição leva credencial.

### 2. Meta Ads mostrava identificador de API, não métrica

A tela despejava a tabela "Origem das conversões": uma linha por `action_type`
que a Meta devolve, com o identificador cru ao lado — `onsite_conversion.post_net_like`,
`post_interaction_gross`, `omni_landing_page_view`. É saída de depuração. Foi
útil uma vez, para responder "de onde vêm esses leads", e virou mobília
permanente numa tela de cliente.

No lugar entram as métricas que se olha numa reunião de mídia:

| Métrica | Observação |
|---|---|
| Impressões | |
| Alcance | Pessoas distintas; somado entre campanhas, e o rótulo avisa |
| Frequência | Impressões por pessoa alcançada |
| CPM | |
| CTR | |
| Cliques no link | Separado do total de cliques |
| Retenção de vídeo | 25/50/75/100%, sobre quem começou a assistir |

**Cliques no link separado do total importa:** o total inclui curtida,
comentário e expansão de imagem, e infla a leitura de tráfego.

**CPM e frequência são recalculados dos totais.** A Insights devolve os dois
por linha, e somar média de dia com média de dia dá número errado — o mesmo
defeito que já tinha aparecido na comparação de razões.

**A tabela de vídeo só aparece quando existe vídeo na conta.** Uma tabela de
zeros ocupa espaço e sugere campanha ruim quando a campanha nem é de vídeo.

### 3. Tabelas longas e valor cortado

A página do Google Ads tinha **12.380px** no desktop: 30 termos de pesquisa,
34 palavras-chave e 25 locais empilhados. Ninguém lê da décima linha em diante
sem procurar algo específico.

`DataTable` passa a mostrar 10 linhas no desktop e 5 no celular, com botão para
abrir o resto. Nada é descartado. O recorte acontece **depois** da ordenação —
senão "as 10 primeiras" mostraria um top 10 que não é top de nada assim que o
usuário trocasse a coluna.

O valor do indicador era cortado com nove KPIs na linha. O tile escalava a
fonte com `vw`, apesar do comentário dizer "escala com o container": o tile
estreitou, a fonte não, e o `overflow-hidden` cortou "R$ 18.783,83". Agora
escala com `cqw`, a largura do próprio tile.

## Como foi validado

- [x] `npm run verify` — tipos, lint, contrato de arquitetura, código morto e **142 testes**
- [x] `npm run test:e2e` — **32/32** (16 desktop, 16 mobile)
- [x] `npm run build` — compila limpo
- [x] **Falha do Google Ads reproduzida localmente**: credencial cadastrada e
      API inalcançável devolve HTTP 200 com R$ 285,12 e o aviso, onde antes
      quebrava
- [x] Alturas medidas em 1440px e 390px: desktop 12.380px → 3.909px, celular
      10.495px → 7.949px
- [x] Checagem programática de estouro de texto nos indicadores, nas duas larguras
- [ ] Métricas do Meta contra a API real — depende de credencial

**Testes novos:** CPM e frequência calculados sobre os totais; cliques no link
distintos do total; retenção de vídeo sobre a base certa; tabela de vídeo
omitida sem vídeo; identificador cru ausente da tela; segredo não vaza no aviso
de falha do Google Ads.

## Riscos e limitações

**As métricas novas do Meta não foram exercitadas contra a API real** — não
tenho acesso à Meta a partir do ambiente de desenvolvimento. Os testes cobrem o
formato que a Insights documenta, o que valida o cálculo, não o contrato. Os
campos `video_play_actions` e `video_p*_watched_actions` são o ponto mais
provável de divergência.

**Alcance é somado entre campanhas.** Quem foi alcançado por duas campanhas
conta duas vezes. O valor exato do período exigiria uma consulta separada sem
`time_increment`; o rótulo diz o que o número é.

**A composição dos leads saiu da tela.** A explicação continua na dica do
indicador, mas quem quiser conferir ação por ação não tem mais onde.

## Próximos passos

- Conferir as métricas de vídeo contra a conta real assim que a tela subir
- Achados de gravidade alta da auditoria seguem abertos (alcance do orgânico e
  usuários do GA4 somados como se fossem aditivos, duração média como média de
  médias)
- Concluir orgânico e Google Ads
- Rotacionar as credenciais que passaram por chat

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_