### PR TITLE
feat: melhores criativos do Meta Ads, com a arte e retenção por anúncio

### DIFF
--- a/src/app/criativos/[id]/imagem/route.ts
+++ b/src/app/criativos/[id]/imagem/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+
+import { getCredentials, getEnv } from "@/server/env";
+import { httpJson, metaAuthHeaders } from "@/server/lib/http";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 15;
+
+/**
+ * Serve a arte de um anúncio pelo próprio domínio.
+ *
+ * A URL do CDN da Meta não vai para o HTML por dois motivos: ela carrega um
+ * token assinado na query, que ficaria visível no código-fonte da página, e a
+ * CSP do painel não abre `img-src` para host de terceiro. O caminho aqui é
+ * `/criativos/<id>/imagem` — fora de `/api`, onde o `no-store` global impediria
+ * o navegador de cachear a arte a cada render.
+ */
+
+/** Só dígitos: o ID entra na URL da Graph, e string livre viraria injeção de caminho. */
+const ID_VALIDO = /^\d{1,25}$/;
+
+/** Hosts que a Meta usa para servir arte de anúncio. */
+const HOSTS_PERMITIDOS = /(^|\.)(fbcdn\.net|facebook\.com)$/;
+
+interface RespostaDoCriativo {
+  creative?: { thumbnail_url?: string; image_url?: string };
+}
+
+export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+
+  if (!ID_VALIDO.test(id)) {
+    return NextResponse.json({ erro: "Identificador inválido." }, { status: 400 });
+  }
+  if (!getCredentials().metaAds) {
+    return NextResponse.json({ erro: "Meta Ads não configurado." }, { status: 404 });
+  }
+
+  const env = getEnv();
+
+  try {
+    const anuncio = await httpJson<RespostaDoCriativo>(
+      `https://graph.facebook.com/${env.META_API_VERSION}/${id}` +
+        "?fields=creative.thumbnail_width(600).thumbnail_height(600){thumbnail_url,image_url}",
+      { headers: metaAuthHeaders(env.META_ACCESS_TOKEN as string) },
+    );
+
+    // `image_url` é a arte em tamanho cheio; `thumbnail_url` existe também para
+    // vídeo, onde a Meta gera o quadro de capa. Preferir a primeira, cair na
+    // segunda.
+    const origem = anuncio.creative?.image_url ?? anuncio.creative?.thumbnail_url;
+    if (!origem) {
+      return NextResponse.json({ erro: "Anúncio sem arte." }, { status: 404 });
+    }
+
+    // A URL vem da Graph, não do cliente, mas conferir o host é o que impede
+    // que uma resposta inesperada transforme esta rota em proxy de saída.
+    const destino = new URL(origem);
+    if (destino.protocol !== "https:" || !HOSTS_PERMITIDOS.test(destino.hostname)) {
+      return NextResponse.json({ erro: "Origem da arte não reconhecida." }, { status: 502 });
+    }
+
+    const arte = await fetch(destino, { signal: AbortSignal.timeout(10_000) });
+    if (!arte.ok || !arte.body) {
+      return NextResponse.json({ erro: "Arte indisponível." }, { status: 502 });
+    }
+
+    const tipo = arte.headers.get("content-type") ?? "";
+    if (!tipo.startsWith("image/")) {
+      return NextResponse.json({ erro: "Origem não devolveu imagem." }, { status: 502 });
+    }
+
+    return new NextResponse(arte.body, {
+      headers: {
+        "content-type": tipo,
+        // `private`: é arte de campanha do cliente, cacheia no navegador de
+        // quem tem acesso, nunca em intermediário compartilhado.
+        "cache-control": "private, max-age=900",
+        "x-content-type-options": "nosniff",
+      },
+    });
+  } catch {
+    // A arte é enfeite do relatório. Falhar aqui devolve 404 e o cartão mostra
+    // o estado sem imagem — nunca um erro que suba para a tela.
+    return NextResponse.json({ erro: "Não foi possível carregar a arte." }, { status: 404 });
+  }
+}

--- a/src/components/report/channel-view.tsx
+++ b/src/components/report/channel-view.tsx
@@ -1,6 +1,7 @@
 import { TrendSmallMultiples } from "@/components/charts/lazy";
 import { Notices } from "@/components/layout/notices";
 import { PageHeader } from "@/components/layout/page-header";
+import { CreativeGrid } from "@/components/report/creative-grid";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { DataTable } from "@/components/ui/data-table";
 import { StatTile } from "@/components/ui/stat-tile";
@@ -68,6 +69,24 @@ export function ChannelView({
           />
         </CardContent>
       </Card>
+
+      {report.creatives && report.creatives.length > 0 ? (
+        <Card className="qy-rise">
+          <CardHeader>
+            <div>
+              <CardTitle>Melhores criativos</CardTitle>
+              <CardDescription>
+                {report.creatives.some((c) => c.leads > 0)
+                  ? "Ordenados por leads, desempatando pelo menor custo por lead."
+                  : "Sem lead atribuído no período, então a ordem é por investimento."}
+              </CardDescription>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <CreativeGrid criativos={report.creatives} />
+          </CardContent>
+        </Card>
+      ) : null}
 
       {report.tables.map((table) => (
         <Card key={table.title} className="qy-rise">

--- a/src/components/report/creative-grid.tsx
+++ b/src/components/report/creative-grid.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { ImageOff } from "lucide-react";
+import { useState } from "react";
+
+import { cn } from "@/lib/cn";
+import { formatMetric } from "@/lib/format";
+import type { CreativeCard } from "@/lib/types";
+
+/** Régua de retenção: quanto do vídeo cada faixa de gente assistiu. */
+function Retencao({ video }: { video: NonNullable<CreativeCard["video"]> }) {
+  const marcas = [
+    { rotulo: "25%", valor: video.p25 },
+    { rotulo: "50%", valor: video.p50 },
+    { rotulo: "75%", valor: video.p75 },
+    { rotulo: "fim", valor: video.p100 },
+  ];
+
+  return (
+    <div className="mt-3 border-line border-t pt-3">
+      <div className="flex items-baseline justify-between">
+        <p className="text-[11px] text-ink-muted">Retenção do vídeo</p>
+        <p className="text-[11px] text-ink-secondary tabular">
+          {formatMetric(video.reproducoes, "integer")} reproduções
+        </p>
+      </div>
+      <div className="mt-2 flex gap-1.5">
+        {marcas.map(({ rotulo, valor }) => (
+          <div key={rotulo} className="min-w-0 flex-1">
+            {/* A barra é a leitura rápida; o número embaixo é a conferência. */}
+            <div
+              className="h-1.5 overflow-hidden rounded-full bg-surface-sunken"
+              role="presentation"
+            >
+              <div
+                className="h-full rounded-full bg-accent"
+                style={{ width: `${Math.min(100, Math.max(0, valor * 100))}%` }}
+              />
+            </div>
+            {/* Duas porcentagens na mesma linha ("25% · 46%") se leem como um
+                valor só. A marca fica acima, muda, e o valor abaixo. */}
+            <p className="mt-1 text-[10px] text-ink-muted leading-tight">{rotulo}</p>
+            <p className="font-medium text-[11px] text-ink tabular leading-tight">
+              {formatMetric(valor, "percent")}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Arte({ criativo }: { criativo: CreativeCard }) {
+  const [falhou, setFalhou] = useState(false);
+
+  if (!criativo.imageUrl || falhou) {
+    return (
+      <div className="flex aspect-[5/4] items-center justify-center bg-surface-sunken">
+        <ImageOff className="size-6 text-ink-muted" aria-hidden="true" />
+        <span className="sr-only">Arte indisponível</span>
+      </div>
+    );
+  }
+
+  return (
+    // `img` puro, não `next/image`: a arte é servida pela própria rota de
+    // proxy, já dimensionada pela Meta, e o otimizador só acrescentaria um
+    // segundo salto para o mesmo byte.
+    // biome-ignore lint/performance/noImgElement: servida pelo proxy do próprio domínio
+    <img
+      src={criativo.imageUrl}
+      alt={`Arte do anúncio ${criativo.name}`}
+      loading="lazy"
+      decoding="async"
+      onError={() => setFalhou(true)}
+      className="aspect-[5/4] w-full bg-surface-sunken object-cover"
+    />
+  );
+}
+
+/**
+ * Os anúncios que trouxeram resultado, com a arte.
+ *
+ * Numa reunião, a pergunta que vem depois de "quanto gastou" é "qual criativo
+ * puxou isso" — e ela não se responde com nome de anúncio numa linha de tabela.
+ */
+export function CreativeGrid({ criativos }: { criativos: CreativeCard[] }) {
+  return (
+    <ul className="qy-stagger grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 xl:grid-cols-4">
+      {criativos.map((criativo, posicao) => (
+        <li
+          key={criativo.id || criativo.name}
+          className={cn(
+            "overflow-hidden rounded-[var(--radius-card)] border border-line bg-surface",
+            "transition-[border-color,box-shadow] duration-[var(--duration-base)] ease-[var(--ease-out-soft)]",
+            "hover:border-line-strong hover:shadow-[0_8px_28px_-20px_rgba(47,37,53,0.4)]",
+          )}
+        >
+          <div className="relative">
+            <Arte criativo={criativo} />
+            <span
+              className="absolute top-2 left-2 rounded-full bg-plum-800/85 px-2 py-0.5 font-medium text-[11px] text-white tabular"
+              aria-hidden="true"
+            >
+              {posicao + 1}
+            </span>
+          </div>
+
+          <div className="p-3.5">
+            <p className="truncate font-semibold text-ink text-sm" title={criativo.name}>
+              {criativo.name}
+            </p>
+            {criativo.campaign ? (
+              <p className="truncate text-[11px] text-ink-muted" title={criativo.campaign}>
+                {criativo.campaign}
+              </p>
+            ) : null}
+
+            <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2">
+              {[
+                { rotulo: "Investimento", valor: criativo.spend, formato: "currency" as const },
+                { rotulo: "Leads", valor: criativo.leads, formato: "integer" as const },
+                { rotulo: "CPL", valor: criativo.cpl, formato: "currency" as const },
+                { rotulo: "CTR", valor: criativo.ctr, formato: "percent" as const },
+                { rotulo: "CPM", valor: criativo.cpm, formato: "currency" as const },
+                {
+                  rotulo: "Impressões",
+                  valor: criativo.impressions,
+                  formato: "integer" as const,
+                },
+              ].map(({ rotulo, valor, formato }) => (
+                <div key={rotulo} className="min-w-0">
+                  <dt className="text-[11px] text-ink-muted leading-tight">{rotulo}</dt>
+                  <dd className="truncate font-medium text-ink text-sm tabular">
+                    {formatMetric(valor, formato)}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+
+            {criativo.video ? <Retencao video={criativo.video} /> : null}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/criativos.ts
+++ b/src/lib/criativos.ts
@@ -1,0 +1,23 @@
+import type { CreativeCard } from "./types";
+
+/**
+ * A ordem dos "melhores criativos".
+ *
+ * "Melhor" é o que trouxe resultado barato, não o que gastou mais: ordena por
+ * leads e desempata pelo menor custo por lead. Sem nenhum lead atribuído no
+ * período, cai para investimento — é o único critério que resta, e a tela diz
+ * qual está em uso.
+ *
+ * Mora aqui, e não no conector, porque a demonstração precisa obedecer à mesma
+ * regra que a legenda anuncia. Quando cada lado ordenava por conta própria, o
+ * mock listava na ordem em que os anúncios foram escritos.
+ */
+export function ordenarCriativos(criativos: CreativeCard[]): CreativeCard[] {
+  const houveLead = criativos.some((c) => c.leads > 0);
+  return [...criativos].sort((a, b) =>
+    houveLead ? b.leads - a.leads || a.cpl - b.cpl : b.spend - a.spend,
+  );
+}
+
+/** Quantos criativos a tela mostra. Passa disso vira catálogo, não leitura. */
+export const MAX_CRIATIVOS = 12;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,6 +76,42 @@ export interface TableBlock {
   initialRows?: number;
 }
 
+/**
+ * Um anúncio, com a arte. Numa reunião a primeira pergunta depois de "quanto
+ * gastou" é "qual criativo puxou isso" — e a resposta é visual.
+ */
+export interface CreativeCard {
+  /** ID do anúncio na Meta. É o que o proxy de imagem usa para achar a arte. */
+  id: string;
+  name: string;
+  campaign?: string;
+  /**
+   * Caminho no próprio domínio. A arte nunca é linkada direto do CDN da Meta:
+   * a URL de lá carrega token assinado na query, e a CSP do painel não abre
+   * para host de terceiro.
+   */
+  imageUrl?: string;
+  spend: number;
+  impressions: number;
+  ctr: number;
+  cpm: number;
+  leads: number;
+  cpl: number;
+  /**
+   * Retenção deste anúncio, quando ele é vídeo. Retenção agregada da conta não
+   * responde a pergunta que importa — qual vídeo segura a atenção — porque a
+   * média junta o que prende com o que é pulado no primeiro segundo.
+   */
+  video?: {
+    reproducoes: number;
+    /** Fração de quem começou e chegou a cada marca. Entre 0 e 1. */
+    p25: number;
+    p50: number;
+    p75: number;
+    p100: number;
+  };
+}
+
 export interface ChannelReport {
   channel: ChannelId;
   label: string;
@@ -94,6 +130,8 @@ export interface ChannelReport {
   /** Período real dos dados, quando difere do intervalo pedido. */
   periodLabel?: string;
   tables: TableBlock[];
+  /** Anúncios com a arte, quando a origem fornece. Só o Meta Ads preenche. */
+  creatives?: CreativeCard[];
   /** Avisos não-fatais: credencial ausente, métrica indisponível, etc. */
   notices: string[];
 }

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -5,6 +5,7 @@
  * (c) storybook visual de estados. Números calibrados para uma operação de
  * tráfego de porte médio — o objetivo é UI realista, não previsão.
  */
+import { ordenarCriativos } from "@/lib/criativos";
 import { eachDay } from "@/lib/date-range";
 import type { ChannelReport, DateRange, SeriesPoint } from "@/lib/types";
 import { dailyValue, noise } from "./generator";
@@ -17,6 +18,35 @@ function sum(points: SeriesPoint[], key: string): number {
 
 function safeDiv(a: number, b: number): number {
   return b === 0 ? 0 : a / b;
+}
+
+/**
+ * Arte de demonstração como SVG embutido.
+ *
+ * A CSP do painel só libera `img-src 'self' data: blob:`, e nenhum dado de
+ * demonstração deve depender de rede para renderizar — o modo mock precisa
+ * funcionar offline, que é metade da razão de ele existir.
+ */
+function arteDeDemonstracao(indice: number): string {
+  const paletas = [
+    ["#2f2535", "#9d5cc1"],
+    ["#4e9e76", "#789180"],
+    ["#9d5cc1", "#d7d2e1"],
+    ["#c96a24", "#2f2535"],
+    ["#4a79d1", "#9d5cc1"],
+  ];
+  const [fundo, brilho] = paletas[indice % paletas.length];
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">` +
+    `<defs><radialGradient id="g" cx="30%" cy="25%" r="85%">` +
+    `<stop offset="0%" stop-color="${brilho}"/>` +
+    `<stop offset="100%" stop-color="${fundo}"/>` +
+    `</radialGradient></defs>` +
+    `<rect width="400" height="400" fill="url(#g)"/>` +
+    `<text x="200" y="216" text-anchor="middle" font-family="sans-serif" ` +
+    `font-size="34" font-weight="600" fill="#ffffff" opacity="0.62">Criativo</text>` +
+    `</svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 }
 
 /* ------------------------------------------------------------------ Meta Ads */
@@ -136,6 +166,60 @@ export function mockMetaAds(range: DateRange, fetchedAt = NOW): ChannelReport {
       { key: "impressions", label: "Impressões", format: "integer", slot: 3 },
       { key: "cpm", label: "CPM", format: "currency", slot: 4 },
     ],
+    // A arte da demonstração é um SVG embutido: a CSP libera `data:`, e nenhum
+    // dado de demonstração deve depender de rede para renderizar.
+    creatives: ordenarCriativos(
+      [
+        ["Vídeo 15s | Antes e depois", "Reconhecimento | Marca | Vídeo 15s", 0.09, 0.05, true],
+        ["Carrossel | Protocolo completo", "Conversão | Emagrecimento | Broad", 0.34, 0.38, false],
+        [
+          "Vídeo 30s | Depoimento médica",
+          "Conversão | Terapia Injetável | Lookalike 1%",
+          0.26,
+          0.29,
+          true,
+        ],
+        [
+          "Estático | Consulta em 24h",
+          "Conversão | Check-up | Interesses saúde",
+          0.14,
+          0.16,
+          false,
+        ],
+        ["Reels | Rotina do tratamento", "Tráfego | Institucional | Retargeting", 0.17, 0.12, true],
+      ].map(([nome, campanha, fatiaSpend, fatiaLeads, ehVideo], i) => {
+        const s = spend * (fatiaSpend as number);
+        // A fatia de impressões não pode ser a mesma do investimento: com as
+        // duas iguais o CPM sai idêntico em todo criativo e a coluna parece
+        // quebrada.
+        const impr = Math.round(
+          impressions * (fatiaSpend as number) * (0.66 + noise(`impr-${i}`) * 0.5),
+        );
+        const l = Math.round(leads * (fatiaLeads as number));
+        const reproducoes = Math.round(impr * 0.31);
+        return {
+          id: `mock-${i}`,
+          name: nome as string,
+          campaign: campanha as string,
+          imageUrl: arteDeDemonstracao(i),
+          spend: Math.round(s * 100) / 100,
+          impressions: impr,
+          ctr: 0.006 + noise(`meta-ctr-criativo-${i}`) * 0.038,
+          cpm: Math.round(safeDiv(s, impr) * 1000 * 100) / 100,
+          leads: l,
+          cpl: Math.round(safeDiv(s, l) * 100) / 100,
+          video: ehVideo
+            ? {
+                reproducoes,
+                p25: 0.38 + noise(`v25-${i}`) * 0.22,
+                p50: 0.2 + noise(`v50-${i}`) * 0.16,
+                p75: 0.12 + noise(`v75-${i}`) * 0.1,
+                p100: 0.06 + noise(`v100-${i}`) * 0.09,
+              }
+            : undefined,
+        };
+      }),
+    ),
     tables: [
       {
         title: "Campanhas",

--- a/src/server/connectors/meta-ads.ts
+++ b/src/server/connectors/meta-ads.ts
@@ -1,7 +1,8 @@
 import "server-only";
 
+import { MAX_CRIATIVOS, ordenarCriativos } from "@/lib/criativos";
 import { eachDay } from "@/lib/date-range";
-import type { ChannelReport, DateRange, SeriesPoint } from "@/lib/types";
+import type { ChannelReport, CreativeCard, DateRange, SeriesPoint } from "@/lib/types";
 import { mockMetaAds } from "@/mocks/reports";
 import { getCredentials, getEnv, isForceMock } from "@/server/env";
 import { httpJson, metaAuthHeaders } from "@/server/lib/http";
@@ -16,6 +17,8 @@ type AcoesDaMeta = Array<{ action_type: string; value: string }>;
 
 interface MetaInsightsRow {
   date_start: string;
+  ad_id?: string;
+  ad_name?: string;
   spend?: string;
   impressions?: string;
   /** Pessoas distintas alcançadas. Não é aditivo entre dias. */
@@ -133,6 +136,43 @@ function somarAcoes(acoes: AcoesDaMeta | undefined): number {
   return (acoes ?? []).reduce((total, item) => total + num(item.value), 0);
 }
 
+/** Monta os cartões de anúncio. A ordem vem de `ordenarCriativos`. */
+function montarCriativos(porAnuncio: MetaInsightsRow[]): CreativeCard[] {
+  const cartoes = porAnuncio.map((row) => {
+    const spend = num(row.spend);
+    const impressions = num(row.impressions);
+    const clicks = num(row.clicks);
+    const leads = countLeads(row);
+    const reproducoes = somarAcoes(row.video_play_actions);
+    return {
+      id: row.ad_id ?? "",
+      name: row.ad_name ?? "—",
+      campaign: row.campaign_name,
+      imageUrl: row.ad_id ? `/criativos/${row.ad_id}/imagem` : undefined,
+      spend,
+      impressions,
+      ctr: impressions === 0 ? 0 : clicks / impressions,
+      cpm: impressions === 0 ? 0 : (spend / impressions) * 1000,
+      leads,
+      cpl: leads === 0 ? 0 : spend / leads,
+      // Sem reprodução não é vídeo — ou é vídeo que ninguém abriu. Nos dois
+      // casos, mostrar uma régua de retenção zerada só ocupa espaço.
+      video:
+        reproducoes > 0
+          ? {
+              reproducoes,
+              p25: somarAcoes(row.video_p25_watched_actions) / reproducoes,
+              p50: somarAcoes(row.video_p50_watched_actions) / reproducoes,
+              p75: somarAcoes(row.video_p75_watched_actions) / reproducoes,
+              p100: somarAcoes(row.video_p100_watched_actions) / reproducoes,
+            }
+          : undefined,
+    } satisfies CreativeCard;
+  });
+
+  return ordenarCriativos(cartoes).slice(0, MAX_CRIATIVOS);
+}
+
 export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelReport> {
   const forceMock = isForceMock();
 
@@ -146,7 +186,7 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
     return report;
   }
 
-  const [daily, byCampaign] = await Promise.all([
+  const [daily, byCampaign, porAnuncio] = await Promise.all([
     fetchInsights(range, {
       fields: CAMPOS_DE_METRICA,
       time_increment: "1",
@@ -156,6 +196,13 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
       fields: `campaign_name,${CAMPOS_DE_METRICA}`,
       level: "campaign",
     }),
+    // Enriquecimento, não requisito: a tela existe sem os criativos. Uma falha
+    // aqui não pode derrubar o relatório inteiro — foi assim que a página do
+    // Google Ads morreu com o dado pronto ao lado.
+    fetchInsights(range, {
+      fields: `ad_id,ad_name,campaign_name,${CAMPOS_DE_METRICA}`,
+      level: "ad",
+    }).catch(() => [] as MetaInsightsRow[]),
   ]);
 
   // A API omite dias sem entrega; a série precisa deles para não "pular" no eixo.
@@ -272,6 +319,7 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
       { key: "impressions", label: "Impressões", format: "integer", slot: 3 },
       { key: "cpm", label: "CPM", format: "currency", slot: 4 },
     ],
+    creatives: montarCriativos(porAnuncio),
     tables: [
       {
         title: "Campanhas",

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -22,7 +22,11 @@ test("navega entre canais mantendo o período escolhido", async ({ page }) => {
   await page.getByRole("link", { name: "Meta Ads" }).first().click();
   await expect(page).toHaveURL(/\/meta-ads\?preset=7d/);
   await expect(page.getByRole("heading", { name: "Meta Ads", level: 1 })).toBeVisible();
-  await expect(page.getByText("Custo por lead")).toBeVisible();
+  // Preso à região de indicadores: solto, o texto casava também com a
+  // legenda dos criativos ("ordenados por ... menor custo por lead").
+  await expect(
+    page.getByRole("region", { name: "Indicadores" }).getByText("Custo por lead"),
+  ).toBeVisible();
 });
 
 test("troca de período atualiza os dados pela URL", async ({ page }) => {

--- a/tests/integration/proxy-criativo.test.ts
+++ b/tests/integration/proxy-criativo.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Proxy da arte do anúncio.
+ *
+ * O risco aqui não é visual: a rota faz uma requisição de saída a partir de um
+ * identificador vindo da URL. Sem as travas, vira proxy aberto.
+ */
+
+async function chamar(id: string) {
+  const { GET } = await import("@/app/criativos/[id]/imagem/route");
+  return GET(new Request(`http://local/criativos/${id}/imagem`), {
+    params: Promise.resolve({ id }),
+  });
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+  vi.stubEnv("QYRA_FORCE_MOCK", "false");
+  vi.stubEnv("META_ACCESS_TOKEN", "token");
+  vi.stubEnv("META_AD_ACCOUNT_ID", "123");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe("proxy da arte do criativo", () => {
+  it("recusa identificador que não seja numérico", async () => {
+    const espiao = vi.fn();
+    vi.stubGlobal("fetch", espiao);
+
+    const resposta = await chamar("../../etc/passwd");
+
+    expect(resposta.status).toBe(400);
+    // A trava tem que barrar antes de qualquer requisição de saída.
+    expect(espiao).not.toHaveBeenCalled();
+  });
+
+  it("recusa arte hospedada fora dos domínios da Meta", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("graph.facebook.com")) {
+          return new Response(
+            JSON.stringify({ creative: { image_url: "https://interno.exemplo/segredo.png" } }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        throw new Error("não deveria buscar host de fora");
+      }),
+    );
+
+    const resposta = await chamar("123456");
+
+    // A URL vem da Graph, não do cliente — mas uma resposta inesperada não pode
+    // transformar a rota em porta de saída para a rede interna.
+    expect(resposta.status).toBe(502);
+  });
+
+  it("recusa origem que não devolve imagem", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("graph.facebook.com")) {
+          return new Response(
+            JSON.stringify({
+              creative: { image_url: "https://scontent.fbcdn.net/v/arte.png" },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response("<html>login</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      }),
+    );
+
+    expect((await chamar("123456")).status).toBe(502);
+  });
+
+  it("entrega a arte com cache privado", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("graph.facebook.com")) {
+          return new Response(
+            JSON.stringify({
+              creative: { image_url: "https://scontent.fbcdn.net/v/arte.png" },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response("bytes", { status: 200, headers: { "content-type": "image/jpeg" } });
+      }),
+    );
+
+    const resposta = await chamar("123456");
+
+    expect(resposta.status).toBe(200);
+    expect(resposta.headers.get("content-type")).toBe("image/jpeg");
+    // `private`: arte de campanha do cliente não pode parar em cache compartilhado.
+    expect(resposta.headers.get("cache-control")).toMatch(/private/);
+  });
+
+  it("falha da Graph vira 404, nunca erro que suba para a tela", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("rede caiu");
+      }),
+    );
+
+    expect((await chamar("123456")).status).toBe(404);
+  });
+});

--- a/tests/unit/criativos.test.ts
+++ b/tests/unit/criativos.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { ordenarCriativos } from "@/lib/criativos";
+import type { CreativeCard } from "@/lib/types";
+
+function criativo(parcial: Partial<CreativeCard> & { name: string }): CreativeCard {
+  return {
+    id: parcial.name,
+    spend: 0,
+    impressions: 0,
+    ctr: 0,
+    cpm: 0,
+    leads: 0,
+    cpl: 0,
+    ...parcial,
+  };
+}
+
+describe("ordem dos melhores criativos", () => {
+  it("põe quem trouxe mais lead na frente, não quem gastou mais", () => {
+    const ordenado = ordenarCriativos([
+      criativo({ name: "caro", spend: 9000, leads: 2, cpl: 4500 }),
+      criativo({ name: "produtivo", spend: 500, leads: 40, cpl: 12.5 }),
+    ]);
+
+    // "Melhor" é resultado, não volume: um anúncio que queimou 9 mil por 2 leads
+    // não abre a lista só porque é o maior número da tela.
+    expect(ordenado.map((c) => c.name)).toEqual(["produtivo", "caro"]);
+  });
+
+  it("desempata pelo menor custo por lead", () => {
+    const ordenado = ordenarCriativos([
+      criativo({ name: "b", spend: 600, leads: 20, cpl: 30 }),
+      criativo({ name: "a", spend: 200, leads: 20, cpl: 10 }),
+    ]);
+
+    expect(ordenado.map((c) => c.name)).toEqual(["a", "b"]);
+  });
+
+  it("sem nenhum lead no período, ordena por investimento", () => {
+    const ordenado = ordenarCriativos([
+      criativo({ name: "pequeno", spend: 100 }),
+      criativo({ name: "grande", spend: 900 }),
+    ]);
+
+    // Com cpl zerado em todos, ordenar por cpl deixaria a lista na ordem de
+    // chegada — que não é ordem nenhuma.
+    expect(ordenado.map((c) => c.name)).toEqual(["grande", "pequeno"]);
+  });
+
+  it("não altera a lista recebida", () => {
+    const original = [
+      criativo({ name: "a", leads: 1, cpl: 10 }),
+      criativo({ name: "b", leads: 9, cpl: 2 }),
+    ];
+    ordenarCriativos(original);
+
+    expect(original.map((c) => c.name)).toEqual(["a", "b"]);
+  });
+});


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — pedido direto durante o uso da tela. Abro a Issue
correspondente (Nova função) referenciando este PR.

## O que mudou

### Grade de criativos

Numa reunião a pergunta que vem depois de "quanto gastou" é "qual criativo
puxou isso", e ela não se responde com nome de anúncio numa linha de tabela.

A tela do Meta Ads ganha uma grade dos anúncios com a arte, investimento,
leads, CPL, CTR, CPM e impressões.

**A ordem é por leads, desempatando pelo menor custo por lead.** "Melhor" é
resultado barato, não volume gasto: um anúncio que queimou 9 mil por 2 leads
não abre a lista só porque é o maior número da tela. Sem lead atribuído no
período cai para investimento, e a legenda diz qual critério está em uso.

### Retenção de vídeo por criativo

Antes só existia agregada. A média da conta junta o que prende com o que é
pulado no primeiro segundo, então ela não responde qual vídeo segura atenção.
Cada cartão de vídeo mostra a régua 25/50/75/100% sobre quem começou a
assistir. Cartão sem reprodução não mostra régua — ou não é vídeo, ou é vídeo
que ninguém abriu, e nos dois casos uma régua zerada só ocupa espaço.

### Proxy da arte

A arte é servida por `/criativos/<id>/imagem`, no próprio domínio, **não
linkada do CDN da Meta**. Três motivos:

1. A URL do CDN carrega token assinado na query, que ficaria visível no
   código-fonte da página
2. A CSP do painel é `img-src 'self' data: blob:` — abrir para host de terceiro
   custaria mais que proxiar
3. A URL do CDN expira

A rota fica **fora de `/api`** de propósito: o `no-store` global aplicado lá
impediria o navegador de cachear a arte a cada render. Aqui o cache é
`private, max-age=900` — cacheia no navegador de quem tem acesso, nunca em
intermediário compartilhado.

**Travas**, que é onde mora o risco de uma rota que faz requisição de saída a
partir de identificador vindo da URL:

| Trava | Comportamento |
|---|---|
| ID não numérico | 400, antes de qualquer requisição de saída |
| Host fora de `fbcdn.net`/`facebook.com` | 502 |
| Resposta sem `content-type` de imagem | 502 |
| Qualquer falha | 404, e o cartão mostra o estado sem arte |

### Robustez

A busca por anúncio é **enriquecimento, não requisito**: falha nela devolve
lista vazia em vez de derrubar o relatório. Foi exatamente assim que a página
do Google Ads morreu com o dado pronto ao lado, no PR anterior.

### Regra de ordenação centralizada

Saiu para `lib/criativos.ts`. O mock ignorava a regra e listava na ordem em que
os anúncios foram escritos — a demonstração mostrava uma ordem que a legenda
não descrevia. Agora conector e mock usam a mesma função.

## Como foi validado

- [x] `npm run verify` — **151 testes** (9 novos)
- [x] `npm run test:e2e` — **32/32**
- [x] `npm run build` — compila limpo
- [x] Conferência visual em 1440px e 390px, com checagem de respostas HTTP ≥400
      na página (nenhuma)

**Testes novos:** ordem por leads e não por gasto; desempate por CPL; queda
para investimento sem leads; a função não altera a lista recebida; e as quatro
travas do proxy mais o caminho de sucesso com cache privado.

**Um teste e2e** procurava `"Custo por lead"` solto e passou a casar também com
a legenda dos criativos. Agora está preso à região de indicadores, que é a
intenção original — o teste ficou mais específico, não mais frouxo.

## Riscos e limitações

**Os campos de criativo não foram exercitados contra a API real** — não alcanço
a Meta a partir do ambiente de desenvolvimento. `creative{thumbnail_url,image_url}`
e o nível `ad` das Insights são o ponto mais provável de divergência. Se a arte
não aparecer em produção, o cartão degrada para o ícone de indisponível em vez
de quebrar, então dá para diagnosticar com a tela no ar.

**Uma requisição por arte.** São até 12 imagens, cada uma custando uma chamada
à Graph mais o download do CDN. Com `private, max-age=900` o navegador não
repete dentro da janela, mas o primeiro carregamento da tela é mais pesado que
antes.

**Cartões da mesma linha esticam para a altura do maior.** Um cartão sem vídeo
ao lado de um com régua de retenção fica com espaço vazio embaixo.

## Próximos passos

- Conferir arte e retenção contra a conta real assim que subir
- Achados de gravidade alta da auditoria seguem abertos (alcance do orgânico e
  usuários do GA4 somados como se fossem aditivos)
- Concluir orgânico e Google Ads
- Rotacionar as credenciais que passaram por chat

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_