### PR TITLE
feat: tira a faixa de aviso do período fixo

### DIFF
--- a/src/server/connectors/google-ads-snapshot.ts
+++ b/src/server/connectors/google-ads-snapshot.ts
@@ -1,4 +1,3 @@
-import { avisoCliente } from "@/lib/avisos";
 import "server-only";
 
 import { GOOGLE_ADS_SNAPSHOT as S } from "@/data/google-ads-snapshot";
@@ -174,12 +173,9 @@ export function buildGoogleAdsSnapshotReport(
       },
     ],
 
-    notices: [
-      // Cliente: explica por que o filtro de data não move este canal. Sem
-      // isso, quem troca o período e vê o mesmo número acha que travou.
-      avisoCliente(
-        `Números reais exportados do Google Ads, referentes a ${S.periodoRotulo} (14 dias). Este canal tem período próprio e não acompanha o filtro de datas acima.`,
-      ),
-    ],
+    // Sem aviso: o cabeçalho da tela já estampa "Período fixo · <intervalo>", e
+    // no resumo por canal o rótulo sai como "Google Ads · período fixo". Uma
+    // faixa amarela repetindo isso só rouba a primeira dobra.
+    notices: [],
   };
 }

--- a/src/server/reports.ts
+++ b/src/server/reports.ts
@@ -1,4 +1,4 @@
-import { avisoCliente, avisoOperacao } from "@/lib/avisos";
+import { avisoOperacao } from "@/lib/avisos";
 import "server-only";
 
 import { CHANNELS, getChannel } from "@/lib/channels";
@@ -199,15 +199,6 @@ export async function getOverviewReport(range: DateRange): Promise<OverviewRepor
   const paidConversions = noPeriodo
     .filter((c) => c.channel === "meta-ads" || c.channel === "google-ads")
     .reduce((a, c) => a + c.conversions, 0);
-
-  for (const canal of byChannel) {
-    if (canal.source !== "snapshot") continue;
-    notices.push(
-      avisoCliente(
-        `${canal.label}: exibido em período próprio e fora do consolidado, porque os dados vêm de um export de intervalo fixo.`,
-      ),
-    );
-  }
 
   const ga4 = results.find((r) => r.channel === "ga4")?.report ?? null;
   const sessions = ga4 ? pickTotal(ga4, ["sessions"]) : 0;

--- a/tests/unit/google-ads-snapshot.test.ts
+++ b/tests/unit/google-ads-snapshot.test.ts
@@ -109,7 +109,15 @@ describe("snapshot do Google Ads", () => {
     expect(soma).toBeCloseTo(285.12, 1);
   });
 
-  it("avisa que o período é fixo e não acompanha o filtro", () => {
-    expect(report.notices.map((n) => n.text).join(" ")).toMatch(/período próprio|periodo próprio/i);
+  it("carrega o período no relatório, para o cabeçalho estampar", () => {
+    // O aviso em faixa saiu — repetia o que o cabeçalho já diz e roubava a
+    // primeira dobra. `periodLabel` é o que sobrou carregando a informação, e
+    // sem ele o cabeçalho mostra só "Período fixo", sem o intervalo.
+    expect(report.source).toBe("snapshot");
+    expect(report.periodLabel).toMatch(/agosto de 2026/);
+  });
+
+  it("não emite aviso em faixa", () => {
+    expect(report.notices).toEqual([]);
   });
 });


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — pedido direto durante uso da tela, antes de uma
apresentação. Abro a Issue correspondente (Melhoria) referenciando este PR.

## O que mudou

Os dois avisos que sobraram depois do #21 **repetiam o que a tela já dizia em
outro lugar**:

| Aviso removido | Onde a informação já estava |
|---|---|
| "Números reais exportados do Google Ads, referentes a 4 de agosto – 17 de agosto de 2026. Este canal tem período próprio…" | Cabeçalho da tela: **"Período fixo · 4 de agosto de 2026 - 17 de agosto de 2026"** |
| "Google Ads: exibido em período próprio e fora do consolidado…" | Resumo por canal: rótulo **"Google Ads · período fixo"** |

Uma faixa amarela repetindo isso ocupava a primeira dobra inteira e empurrava
os indicadores para baixo. Numa apresentação, o que aparece primeiro passava a
ser o alerta em vez do resultado.

**A informação não some** — fica onde já estava. `periodLabel` continua sendo o
campo que o cabeçalho lê.

### O que **não** foi removido

O selo **"Dados de demonstração"**. Ele não é redundante com nada: é o que
separa número real de número fictício, e Analytics e Orgânico ainda estão em
demonstração.

### Estado atual

Nenhuma tela emite faixa hoje. O mecanismo (`Notice`, `Notices`, a audiência
introduzida no #21) continua de pé para quando houver algo que realmente valha
interromper a leitura.

## Como foi validado

- [x] `npm run verify` — **157 testes**
- [x] `npm run test:e2e` — **32/32**
- [x] `npm run build` — compila limpo
- [x] **Contagem de `role="status"` no HTML servido** das cinco telas: zero em
      todas
- [x] Confirmado que `Período fixo · 4 de agosto de 2026 - 17 de agosto de 2026`
      continua no HTML da tela do Google Ads
- [x] Captura em 1440px, tema escuro

O teste que cobria o texto do aviso virou teste do `periodLabel` — o invariante
que passou a carregar a informação. Sem ele o cabeçalho mostraria só "Período
fixo", sem o intervalo, e ninguém perceberia.

## Riscos e limitações

**Quem abrir o consolidado não é mais avisado em faixa de que o Google Ads está
fora do total.** O rótulo "· período fixo" no resumo por canal é a única pista,
e é discreta. Se em algum momento alguém somar as colunas na mão e estranhar a
diferença, é aqui que a explicação sumiu.

**A faixa de avisos hoje nunca aparece.** Se um aviso genuinamente importante
for adicionado no futuro, ninguém terá visto o componente funcionando em
produção — vale conferir o comportamento quando isso acontecer.

## Próximos passos

- Versão da API do Google Ads: o `404` na tela veio de `v18`, já descontinuada.
  Mesmo com o token aprovado, a integração ao vivo não subiria
- Autenticação (#11) antes de `dashboard.qyra.com.br` ficar público
- Achados de gravidade alta da auditoria seguem abertos
- Rotacionar as credenciais que passaram por chat

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_