### PR TITLE
feat: origem das visitas por UTM no Analytics, com post separado por utm_content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,7 @@ recuperação, e funcionamento em tema claro e escuro.
 | `README.md` | Como rodar, scripts, visão geral |
 | `AGENTS.md` | Este contrato |
 | `docs/design-system.md` | Tokens, tipografia, componentes, regras de gráfico |
+| `docs/utm.md` | Padrão de UTM — o que a tabela de origem do Analytics lê |
 | `docs/arquitetura.md` | Camadas, fluxo de dados, decisões |
 | `docs/integracoes.md` | Como obter credencial de cada plataforma |
 | `docs/qualidade.md` | Esteira, observabilidade, orçamento de performance |

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ contrato de contribuição — para pessoas e para agentes:
 | [`docs/design-system.md`](docs/design-system.md) | Tokens da marca, componentes, regras de gráfico |
 | [`docs/arquitetura.md`](docs/arquitetura.md) | Camadas, fluxo de dados, decisões |
 | [`docs/integracoes.md`](docs/integracoes.md) | Credenciais de cada plataforma |
+| [`docs/utm.md`](docs/utm.md) | Padrão de UTM dos links publicados |
 | [`docs/qualidade.md`](docs/qualidade.md) | Esteira, observabilidade, performance |
 | [`docs/deploy.md`](docs/deploy.md) | Vercel, ambientes, domínio |
 | [`docs/legal/`](docs/legal/) | Termos e privacidade (minuta, pendente de jurídico) |

--- a/docs/utm.md
+++ b/docs/utm.md
@@ -7,7 +7,14 @@ trouxe a visita.
 Este documento é a referência do padrão. O painel lê exatamente estes campos na
 tabela **"Origem das visitas"** da tela de Analytics.
 
-## Formato
+## Regras comuns
+
+- Tudo minúsculo, sem acento, sem espaço — separador é `_`
+- `utm_source` é a rede: `linkedin`, `instagram`
+- O que muda entre orgânico e pago é **só** o `utm_medium`
+- Com encurtador, a UTM vai na **URL de destino**, não na encurtada
+
+## LinkedIn
 
 **Post orgânico**
 
@@ -27,13 +34,51 @@ tabela **"Origem das visitas"** da tela de Analytics.
 https://qyra.com.br/plano?utm_source=linkedin&utm_medium=social&utm_campaign=institucional_ago&utm_content=post_caneta
 ```
 
-## Regras
+Link no primeiro comentário funciona igual: mantém a UTM normalmente.
 
-- Tudo minúsculo, sem acento, sem espaço — separador é `_`
-- `utm_source` é a rede: `linkedin`, `instagram`
-- O que muda entre orgânico e pago é **só** o `utm_medium`
-- Com encurtador, a UTM vai na **URL de destino**, não na encurtada
-- Link no primeiro comentário funciona igual: mantém a UTM normalmente
+## Instagram
+
+**Post orgânico (link na bio)**
+
+```
+?utm_source=instagram&utm_medium=social&utm_campaign=TEMA_MES&utm_content=IDENTIFICACAO_DO_POST
+```
+
+**Stories (sticker de link)**
+
+```
+?utm_source=instagram&utm_medium=social&utm_campaign=TEMA_MES&utm_content=stories_IDENTIFICACAO
+```
+
+**Anúncio**
+
+```
+?utm_source=instagram&utm_medium=paid_social&utm_campaign=NOME_DA_CAMPANHA&utm_content=CRIATIVO
+```
+
+**Exemplo pronto**
+
+```
+https://qyra.com.br/plano?utm_source=instagram&utm_medium=social&utm_campaign=institucional_ago&utm_content=stories_caneta
+```
+
+### A diferença que muda a operação
+
+No LinkedIn cada post carrega o próprio link, então cada um vira uma linha
+sozinho na tabela. **No Instagram legenda e comentário não são clicáveis** —
+link só funciona na bio e no sticker de stories.
+
+Consequência: se a bio fica com um link fixo o mês inteiro, todos os posts do
+mês chegam com a mesma UTM e viram **uma linha só**. Para separar post a post, a
+bio precisa ser trocada a cada post, com o `utm_content` daquele post.
+
+Stories é onde a atribuição fica limpa sem esforço — cada sticker carrega a
+própria URL. O prefixo `stories_` no `utm_content` separa na tabela sem precisar
+de coluna nova.
+
+Se a bio aponta para Linktree ou encurtador, a UTM tem que estar em **cada link
+de destino dentro dele**. Na URL encurtada, o GA4 recebe a mesma marcação para
+todo mundo.
 
 ## O que cada campo vira no painel
 

--- a/docs/utm.md
+++ b/docs/utm.md
@@ -1,0 +1,68 @@
+# Padrão de UTM
+
+Todo link publicado fora do site vai **com parâmetros, nunca puro**. Sem UTM a
+sessão cai em "direto" ou "referral" no GA4, e não há como saber qual post
+trouxe a visita.
+
+Este documento é a referência do padrão. O painel lê exatamente estes campos na
+tabela **"Origem das visitas"** da tela de Analytics.
+
+## Formato
+
+**Post orgânico**
+
+```
+?utm_source=linkedin&utm_medium=social&utm_campaign=TEMA_MES&utm_content=IDENTIFICACAO_DO_POST
+```
+
+**Anúncio**
+
+```
+?utm_source=linkedin&utm_medium=paid_social&utm_campaign=NOME_DA_CAMPANHA&utm_content=CRIATIVO
+```
+
+**Exemplo pronto**
+
+```
+https://qyra.com.br/plano?utm_source=linkedin&utm_medium=social&utm_campaign=institucional_ago&utm_content=post_caneta
+```
+
+## Regras
+
+- Tudo minúsculo, sem acento, sem espaço — separador é `_`
+- `utm_source` é a rede: `linkedin`, `instagram`
+- O que muda entre orgânico e pago é **só** o `utm_medium`
+- Com encurtador, a UTM vai na **URL de destino**, não na encurtada
+- Link no primeiro comentário funciona igual: mantém a UTM normalmente
+
+## O que cada campo vira no painel
+
+| Parâmetro | Dimensão no GA4 | Coluna na tela |
+|---|---|---|
+| `utm_source` + `utm_medium` | `sessionSource`, `sessionMedium` | Origem / mídia |
+| `utm_campaign` | `sessionCampaignName` | Campanha |
+| `utm_content` | `sessionManualAdContent` | Post / criativo |
+
+**`utm_campaign` é o tema, `utm_content` é o post.** Essa distinção é o que
+torna a tabela útil: sem `utm_content`, todos os posts de `institucional_ago`
+viram uma linha só, e some justamente a granularidade que responde "qual post
+trouxe gente".
+
+## Por que a caixa importa
+
+O GA4 trata `Instagram` e `instagram` como valores diferentes — viram duas
+linhas separadas na mesma tabela, cada uma com parte das sessões. Não há como
+juntar depois sem reprocessar. Por isso minúsculas sempre.
+
+## Por que `utm_medium` importa
+
+O `utm_medium` é o que decide o agrupamento padrão do GA4:
+
+| `utm_medium` | Agrupamento |
+|---|---|
+| `social` | Organic Social |
+| `paid_social` | Paid Social |
+| `cpc` | Paid Search |
+
+Marcar um post orgânico como `cpc` mistura ele com o tráfego pago do Meta e do
+Google no consolidado. É erro difícil de perceber depois.

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -489,6 +489,38 @@ export function mockGa4(range: DateRange, fetchedAt = NOW): ChannelReport {
         }),
       },
       {
+        title: "Origem das visitas",
+        description:
+          "De onde a sessão veio, pela UTM do link. É aqui que se vê qual post de Instagram ou LinkedIn trouxe gente — o agrupamento acima junta tudo num balde só.",
+        columns: [
+          { key: "origem", label: "Origem / mídia", align: "left" },
+          { key: "campanha", label: "Campanha", align: "left" },
+          { key: "sessions", label: "Sessões", format: "integer", align: "right" },
+          { key: "conversions", label: "Conversões", format: "integer", align: "right" },
+          { key: "rate", label: "Taxa de conversão", format: "percent", align: "right" },
+        ],
+        rows: [
+          ["instagram / social", "bio-agosto", 0.14, 0.16],
+          ["instagram / social", "post-emagrecimento-12ago", 0.11, 0.13],
+          ["facebook / cpc", "conversao-broad", 0.19, 0.22],
+          ["linkedin / social", "artigo-terapia-injetavel", 0.08, 0.09],
+          ["google / cpc", "search-intencao", 0.16, 0.18],
+          ["google / organic", "não informado", 0.13, 0.07],
+          ["linkedin / social", "vaga-institucional", 0.04, 0.02],
+          ["direto / sem mídia", "não informado", 0.15, 0.13],
+        ].map(([origem, campanha, fs, fc]) => {
+          const se = Math.round(sessions * (fs as number));
+          const co = Math.round(conversions * (fc as number));
+          return {
+            origem: origem as string,
+            campanha: campanha as string,
+            sessions: se,
+            conversions: co,
+            rate: safeDiv(co, se),
+          };
+        }),
+      },
+      {
         title: "Páginas mais vistas",
         columns: [
           { key: "page", label: "Página", align: "left" },

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -491,29 +491,34 @@ export function mockGa4(range: DateRange, fetchedAt = NOW): ChannelReport {
       {
         title: "Origem das visitas",
         description:
-          "De onde a sessão veio, pela UTM do link. É aqui que se vê qual post de Instagram ou LinkedIn trouxe gente — o agrupamento acima junta tudo num balde só.",
+          "De onde a sessão veio, pela UTM do link. `utm_campaign` é o tema, `utm_content` é o post — é a segunda que separa um post do outro dentro do mesmo mês.",
         columns: [
           { key: "origem", label: "Origem / mídia", align: "left" },
           { key: "campanha", label: "Campanha", align: "left" },
+          { key: "conteudo", label: "Post / criativo", align: "left" },
           { key: "sessions", label: "Sessões", format: "integer", align: "right" },
           { key: "conversions", label: "Conversões", format: "integer", align: "right" },
           { key: "rate", label: "Taxa de conversão", format: "percent", align: "right" },
         ],
+        // Segue o padrão de UTM da Qyra: campanha é o tema do mês, conteúdo é
+        // o post. Dois posts do mesmo tema aparecem como linhas separadas.
         rows: [
-          ["instagram / social", "bio-agosto", 0.14, 0.16],
-          ["instagram / social", "post-emagrecimento-12ago", 0.11, 0.13],
-          ["facebook / cpc", "conversao-broad", 0.19, 0.22],
-          ["linkedin / social", "artigo-terapia-injetavel", 0.08, 0.09],
-          ["google / cpc", "search-intencao", 0.16, 0.18],
-          ["google / organic", "não informado", 0.13, 0.07],
-          ["linkedin / social", "vaga-institucional", 0.04, 0.02],
-          ["direto / sem mídia", "não informado", 0.15, 0.13],
-        ].map(([origem, campanha, fs, fc]) => {
+          ["linkedin / social", "institucional_ago", "post_caneta", 0.13, 0.15],
+          ["linkedin / social", "institucional_ago", "post_checkup", 0.07, 0.08],
+          ["instagram / social", "institucional_ago", "bio", 0.12, 0.14],
+          ["instagram / social", "emagrecimento_ago", "reels_antes_depois", 0.1, 0.12],
+          ["facebook / paid_social", "conversao_broad", "criativo_video15s", 0.16, 0.19],
+          ["linkedin / paid_social", "terapia_injetavel_ago", "criativo_estatico", 0.05, 0.05],
+          ["google / cpc", "search_intencao", "não informado", 0.15, 0.16],
+          ["google / organic", "não informado", "não informado", 0.11, 0.06],
+          ["direto / sem mídia", "não informado", "não informado", 0.11, 0.05],
+        ].map(([origem, campanha, conteudo, fs, fc]) => {
           const se = Math.round(sessions * (fs as number));
           const co = Math.round(conversions * (fc as number));
           return {
             origem: origem as string,
             campanha: campanha as string,
+            conteudo: conteudo as string,
             sessions: se,
             conversions: co,
             rate: safeDiv(co, se),

--- a/src/server/connectors/ga4.ts
+++ b/src/server/connectors/ga4.ts
@@ -115,6 +115,11 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
         { name: "sessionSource" },
         { name: "sessionMedium" },
         { name: "sessionCampaignName" },
+        // `utm_content` no padrão da Qyra identifica o post ou o criativo, e
+        // `utm_campaign` é o tema do mês. Sem esta dimensão, todos os posts de
+        // agosto colapsam numa linha "institucional_ago" só — justamente a
+        // granularidade que interessa para saber qual post trouxe gente.
+        { name: "sessionManualAdContent" },
       ],
       metrics: [{ name: "sessions" }, { name: "conversions" }],
       orderBys: [{ metric: { metricName: "sessions" }, desc: true }],
@@ -207,10 +212,11 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
       {
         title: "Origem das visitas",
         description:
-          "De onde a sessão veio, pela UTM do link. É aqui que se vê qual post de Instagram ou LinkedIn trouxe gente — o agrupamento acima junta tudo num balde só.",
+          "De onde a sessão veio, pela UTM do link. `utm_campaign` é o tema, `utm_content` é o post — é a segunda que separa um post do outro dentro do mesmo mês.",
         columns: [
           { key: "origem", label: "Origem / mídia", align: "left" },
           { key: "campanha", label: "Campanha", align: "left" },
+          { key: "conteudo", label: "Post / criativo", align: "left" },
           { key: "sessions", label: "Sessões", format: "integer", align: "right" },
           { key: "conversions", label: "Conversões", format: "integer", align: "right" },
           { key: "rate", label: "Taxa de conversão", format: "percent", align: "right" },
@@ -223,6 +229,7 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
           return {
             origem: `${origem} / ${midia}`,
             campanha: rotularOrigem(row.dimensionValues?.[2]?.value),
+            conteudo: rotularOrigem(row.dimensionValues?.[3]?.value),
             sessions,
             conversions,
             rate: sessions === 0 ? 0 : conversions / sessions,

--- a/src/server/connectors/ga4.ts
+++ b/src/server/connectors/ga4.ts
@@ -25,6 +25,23 @@ function num(value: string | undefined): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+/**
+ * O GA4 devolve marcadores próprios para tráfego sem UTM. Traduzir aqui evita
+ * que "(not set)" apareça na tela do cliente parecendo defeito.
+ */
+const ROTULO_DE_ORIGEM: Record<string, string> = {
+  "(not set)": "não informado",
+  "(direct)": "direto",
+  "(none)": "sem mídia",
+  "(organic)": "orgânico",
+};
+
+function rotularOrigem(valor: string | undefined): string {
+  const bruto = valor?.trim();
+  if (!bruto) return "não informado";
+  return ROTULO_DE_ORIGEM[bruto] ?? bruto;
+}
+
 async function runReport(body: unknown): Promise<RunReportResponse> {
   const env = getEnv();
   const token = await getGoogleAccessToken();
@@ -60,7 +77,7 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
 
   const dateRanges = [{ startDate: range.from, endDate: range.to }];
 
-  const [daily, byChannel, byPage] = await Promise.all([
+  const [daily, byChannel, byPage, byUtm] = await Promise.all([
     runReport({
       dateRanges,
       dimensions: [{ name: "date" }],
@@ -87,6 +104,21 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
       metrics: [{ name: "screenPageViews" }, { name: "averageSessionDuration" }],
       orderBys: [{ metric: { metricName: "screenPageViews" }, desc: true }],
       limit: 15,
+    }),
+    // O agrupamento padrão do GA4 joga todo link de rede social no mesmo balde.
+    // Para saber qual post trouxe visita é preciso a origem crua: é o que a
+    // UTM carrega, e é o único jeito de separar Instagram de LinkedIn, e um
+    // post do outro dentro da mesma rede.
+    runReport({
+      dateRanges,
+      dimensions: [
+        { name: "sessionSource" },
+        { name: "sessionMedium" },
+        { name: "sessionCampaignName" },
+      ],
+      metrics: [{ name: "sessions" }, { name: "conversions" }],
+      orderBys: [{ metric: { metricName: "sessions" }, desc: true }],
+      limit: 40,
     }),
   ]);
 
@@ -166,6 +198,31 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
           const conversions = num(row.metricValues?.[1]?.value);
           return {
             channel: row.dimensionValues?.[0]?.value ?? "—",
+            sessions,
+            conversions,
+            rate: sessions === 0 ? 0 : conversions / sessions,
+          };
+        }),
+      },
+      {
+        title: "Origem das visitas",
+        description:
+          "De onde a sessão veio, pela UTM do link. É aqui que se vê qual post de Instagram ou LinkedIn trouxe gente — o agrupamento acima junta tudo num balde só.",
+        columns: [
+          { key: "origem", label: "Origem / mídia", align: "left" },
+          { key: "campanha", label: "Campanha", align: "left" },
+          { key: "sessions", label: "Sessões", format: "integer", align: "right" },
+          { key: "conversions", label: "Conversões", format: "integer", align: "right" },
+          { key: "rate", label: "Taxa de conversão", format: "percent", align: "right" },
+        ],
+        rows: (byUtm.rows ?? []).map((row) => {
+          const sessions = num(row.metricValues?.[0]?.value);
+          const conversions = num(row.metricValues?.[1]?.value);
+          const origem = rotularOrigem(row.dimensionValues?.[0]?.value);
+          const midia = rotularOrigem(row.dimensionValues?.[1]?.value);
+          return {
+            origem: `${origem} / ${midia}`,
+            campanha: rotularOrigem(row.dimensionValues?.[2]?.value),
             sessions,
             conversions,
             rate: sessions === 0 ? 0 : conversions / sessions,

--- a/tests/integration/connectors.test.ts
+++ b/tests/integration/connectors.test.ts
@@ -598,6 +598,9 @@ describe("GA4 — origem das visitas por UTM", () => {
     expect(pedidos).toContain("sessionSource");
     expect(pedidos).toContain("sessionMedium");
     expect(pedidos).toContain("sessionCampaignName");
+    // `utm_content` é o que separa um post do outro dentro do mesmo tema, no
+    // padrão de UTM em uso. Sem ele a tabela agrega o mês inteiro numa linha.
+    expect(pedidos).toContain("sessionManualAdContent");
   });
 
   it("traduz os marcadores do GA4 em vez de mostrar (not set)", async () => {
@@ -627,7 +630,8 @@ describe("GA4 — origem das visitas por UTM", () => {
                 dimensionValues: [
                   { value: "instagram" },
                   { value: "social" },
-                  { value: "bio-agosto" },
+                  { value: "institucional_ago" },
+                  { value: "post_caneta" },
                 ],
                 metricValues: [{ value: "50" }, { value: "5" }],
               },
@@ -635,6 +639,7 @@ describe("GA4 — origem das visitas por UTM", () => {
                 dimensionValues: [
                   { value: "(direct)" },
                   { value: "(none)" },
+                  { value: "(not set)" },
                   { value: "(not set)" },
                 ],
                 metricValues: [{ value: "20" }, { value: "0" }],
@@ -652,7 +657,8 @@ describe("GA4 — origem das visitas por UTM", () => {
 
     expect(tabela?.rows[0]).toMatchObject({
       origem: "instagram / social",
-      campanha: "bio-agosto",
+      campanha: "institucional_ago",
+      conteudo: "post_caneta",
       sessions: 50,
       rate: 0.1,
     });

--- a/tests/integration/connectors.test.ts
+++ b/tests/integration/connectors.test.ts
@@ -564,3 +564,100 @@ describe("Google Ads — token aguardando aprovação", () => {
     expect(report.notices[0].text).toMatch(/oculto/);
   });
 });
+
+describe("GA4 — origem das visitas por UTM", () => {
+  it("pede a origem crua, não só o agrupamento padrão", async () => {
+    await withCredentials({ ...GOOGLE_OAUTH, GA4_PROPERTY_ID: "123" });
+
+    const corpos: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("oauth2.googleapis.com")) {
+          return new Response(JSON.stringify(TOKEN_RESPONSE), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        corpos.push(String(init?.body ?? ""));
+        return new Response(JSON.stringify({ rows: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+
+    const { fetchGa4Report } = await import("@/server/connectors/ga4");
+    await fetchGa4Report(RANGE);
+
+    // `sessionDefaultChannelGroup` joga Instagram e LinkedIn no mesmo balde.
+    // Sem estas três dimensões, a UTM que a equipe monta no post não aparece
+    // em lugar nenhum do painel.
+    const pedidos = corpos.join(" ");
+    expect(pedidos).toContain("sessionSource");
+    expect(pedidos).toContain("sessionMedium");
+    expect(pedidos).toContain("sessionCampaignName");
+  });
+
+  it("traduz os marcadores do GA4 em vez de mostrar (not set)", async () => {
+    await withCredentials({ ...GOOGLE_OAUTH, GA4_PROPERTY_ID: "123" });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("oauth2.googleapis.com")) {
+          return new Response(JSON.stringify(TOKEN_RESPONSE), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        const corpo = String(init?.body ?? "");
+        if (!corpo.includes("sessionCampaignName")) {
+          return new Response(JSON.stringify({ rows: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(
+          JSON.stringify({
+            rows: [
+              {
+                dimensionValues: [
+                  { value: "instagram" },
+                  { value: "social" },
+                  { value: "bio-agosto" },
+                ],
+                metricValues: [{ value: "50" }, { value: "5" }],
+              },
+              {
+                dimensionValues: [
+                  { value: "(direct)" },
+                  { value: "(none)" },
+                  { value: "(not set)" },
+                ],
+                metricValues: [{ value: "20" }, { value: "0" }],
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }),
+    );
+
+    const { fetchGa4Report } = await import("@/server/connectors/ga4");
+    const report = await fetchGa4Report(RANGE);
+    const tabela = report.tables.find((t) => t.title === "Origem das visitas");
+
+    expect(tabela?.rows[0]).toMatchObject({
+      origem: "instagram / social",
+      campanha: "bio-agosto",
+      sessions: 50,
+      rate: 0.1,
+    });
+    // "(not set)" na tela do cliente parece defeito, não ausência de UTM.
+    expect(JSON.stringify(tabela?.rows)).not.toMatch(/\(not set\)|\(direct\)|\(none\)/);
+    expect(tabela?.rows[1]).toMatchObject({ origem: "direto / sem mídia" });
+  });
+});


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — surgiu de uma pergunta direta: "estou colocando UTM no
Instagram e no LinkedIn, onde vamos ver esses dados?". A resposta era: em lugar
nenhum. Abro a Issue correspondente (Nova função) referenciando este PR.

## O que mudou

A tela do Analytics pedia ao GA4 apenas `sessionDefaultChannelGroup` — o
agrupamento padrão. Nele, um link de Instagram e um de LinkedIn caem os dois em
**"Organic Social"**, e a UTM de cada post não aparecia em lugar nenhum do
painel.

**O dado já estava no GA4. Só não era consultado.**

Entra a tabela **"Origem das visitas"**:

| Parâmetro | Dimensão GA4 | Coluna |
|---|---|---|
| `utm_source` + `utm_medium` | `sessionSource`, `sessionMedium` | Origem / mídia |
| `utm_campaign` | `sessionCampaignName` | Campanha |
| `utm_content` | `sessionManualAdContent` | Post / criativo |

Mais sessões, conversões e taxa de conversão.

### `utm_content` é o que faz a tabela valer

No padrão em uso na Qyra, **`utm_campaign` é o tema do mês e `utm_content` é o
post**. Sem a terceira dimensão, dois posts de `institucional_ago` colapsariam
numa linha só — sumindo justamente a granularidade que responde "qual post
trouxe gente".

A primeira versão deste PR não pedia `utm_content`. Foi corrigido antes do
merge, depois que o padrão da equipe ficou explícito.

### Tradução dos marcadores

O GA4 devolve `(not set)`, `(direct)` e `(none)` para tráfego sem UTM. Na tela
do cliente isso parece defeito, não ausência de marcação. Viram "não
informado", "direto" e "sem mídia".

### O padrão vira documento do projeto

`docs/utm.md`, referenciado no README e no `AGENTS.md`. Combinação de UTM
decidida em conversa se perde, e o painel lê campos específicos — quem publica
precisa saber quais.

O documento registra duas armadilhas que custam caro depois:

- **Caixa importa.** O GA4 trata `Instagram` e `instagram` como valores
  distintos: viram duas linhas, cada uma com parte das sessões, e não há como
  juntar sem reprocessar.
- **`utm_medium` decide o agrupamento.** Marcar post orgânico como `cpc` mistura
  ele com o tráfego pago do Meta e do Google no consolidado — erro difícil de
  perceber meses depois.

## Como foi validado

- [x] `npm run verify` — **159 testes** (2 novos)
- [x] `npm run test:e2e` — **32/32**
- [x] `npm run build` — compila limpo
- [x] Captura em 1440px confirmando que dois posts do mesmo tema aparecem como
      linhas separadas

**Testes novos:**
1. As quatro dimensões são efetivamente pedidas ao GA4 — o teste inspeciona o
   corpo das requisições. Sem isso, uma regressão devolveria a tabela agregada
   sem ninguém notar.
2. Nenhum marcador cru (`(not set)`, `(direct)`, `(none)`) chega à tela.

## Riscos e limitações

**Não exercitado contra a propriedade real.** As dimensões são as documentadas
na Data API v1beta, mas não consigo alcançar o GA4 da Qyra deste ambiente.

**A tabela vai nascer quase vazia.** A tag do GA4 foi instalada há poucos dias
e o volume ainda é baixo. Ela só fica útil conforme os links acumularem
tráfego.

**Atribuição é por sessão, não por clique.** Quem chegou pelo Instagram e voltou
depois pelo Google aparece nas duas linhas, em sessões diferentes. É o padrão do
GA4, mas vale saber ao comparar com os cliques que o Instagram reporta.

**Limite de 40 linhas**, ordenadas por sessões. Com muitas campanhas ativas a
cauda fica de fora, e o corte não é anunciado na tela.

**Encurtador quebra a granularidade.** Se a UTM ficar na URL encurtada em vez da
de destino, todos os posts colapsam numa linha. Está no documento, mas depende
de quem publica seguir.

## Próximos passos

- Conferir contra a propriedade real quando houver volume
- Versão da API do Google Ads: o `404` em produção vem de `v18`, descontinuada
- Autenticação (#11) antes do domínio público
- Achados de gravidade alta da auditoria seguem abertos