### PR TITLE
fix: duração média do GA4 estava errada e o tempo por página media outra coisa

### DIFF
--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -527,13 +527,23 @@ export function mockGa4(range: DateRange, fetchedAt = NOW): ChannelReport {
       },
       {
         title: "Páginas mais vistas",
+        description:
+          "Tempo é de engajamento por visualização — quanto a pessoa passou naquela página, não quanto durou a sessão inteira dela.",
         columns: [
           { key: "page", label: "Página", align: "left" },
+          { key: "path", label: "Endereço", align: "left" },
           { key: "views", label: "Visualizações", format: "integer", align: "right" },
           { key: "avgDuration", label: "Tempo médio", format: "duration", align: "right" },
         ],
-        rows: ["/", "/planos", "/terapia-injetavel", "/agendar", "/sobre"].map((page, i) => ({
+        rows: [
+          ["Qyra — Sua melhor versão começa agora", "/"],
+          ["Planos e preços", "/planos"],
+          ["Terapia injetável para emagrecimento", "/terapia-injetavel"],
+          ["Agendar consulta", "/agendar"],
+          ["Sobre a Qyra", "/sobre"],
+        ].map(([page, path], i) => ({
           page,
+          path,
           views: Math.round(sessions * [0.42, 0.21, 0.16, 0.13, 0.08][i]),
           avgDuration: 60 + noise(`ga4:pg:${i}`) * 180,
         })),

--- a/src/server/connectors/ga4.ts
+++ b/src/server/connectors/ga4.ts
@@ -100,8 +100,15 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
     }),
     runReport({
       dateRanges,
-      dimensions: [{ name: "pagePath" }],
-      metrics: [{ name: "screenPageViews" }, { name: "averageSessionDuration" }],
+      // `pagePath` sozinho devolve "/plano", "/", "/blog/artigo-3" — endereço,
+      // não nome. O título é o que a pessoa lendo o relatório reconhece.
+      dimensions: [{ name: "pageTitle" }, { name: "pagePath" }],
+      // `averageSessionDuration` é métrica de sessão: cruzada com página, ela
+      // devolve a duração das sessões que passaram por ali, não o tempo gasto
+      // naquela página. Era por isso que o número não fechava com o indicador
+      // do topo. `userEngagementDuration` dividido por visualizações é o tempo
+      // de engajamento por visualização, que é o que a coluna promete.
+      metrics: [{ name: "screenPageViews" }, { name: "userEngagementDuration" }],
       orderBys: [{ metric: { metricName: "screenPageViews" }, desc: true }],
       limit: 15,
     }),
@@ -155,7 +162,10 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
       sessions: acc.sessions + Number(p.sessions),
       users: acc.users + Number(p.users),
       conversions: acc.conversions + Number(p.conversions),
-      duration: acc.duration + Number(p.avgDuration),
+      // Duração é média por sessão, e média não se soma. Reconstruindo o tempo
+      // total do dia (média x sessões) a soma volta a ser exata: um dia com 2
+      // sessões deixa de pesar igual a um dia com 200.
+      duration: acc.duration + Number(p.avgDuration) * Number(p.sessions),
     }),
     { sessions: 0, users: 0, conversions: 0, duration: 0 },
   );
@@ -179,8 +189,9 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
       {
         key: "avgDuration",
         label: "Duração média",
-        value: series.length === 0 ? 0 : totals.duration / series.length,
+        value: totals.sessions === 0 ? 0 : totals.duration / totals.sessions,
         format: "duration",
+        hint: "Tempo médio por sessão no período, ponderado pelo volume de cada dia — não é a média das médias diárias.",
       },
     ],
     series,
@@ -238,16 +249,28 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
       },
       {
         title: "Páginas mais vistas",
+        description:
+          "Tempo é de engajamento por visualização — quanto a pessoa passou naquela página, não quanto durou a sessão inteira dela.",
         columns: [
           { key: "page", label: "Página", align: "left" },
+          { key: "path", label: "Endereço", align: "left" },
           { key: "views", label: "Visualizações", format: "integer", align: "right" },
           { key: "avgDuration", label: "Tempo médio", format: "duration", align: "right" },
         ],
-        rows: (byPage.rows ?? []).map((row) => ({
-          page: row.dimensionValues?.[0]?.value ?? "—",
-          views: num(row.metricValues?.[0]?.value),
-          avgDuration: num(row.metricValues?.[1]?.value),
-        })),
+        rows: (byPage.rows ?? []).map((row) => {
+          const views = num(row.metricValues?.[0]?.value);
+          const engajamento = num(row.metricValues?.[1]?.value);
+          const titulo = row.dimensionValues?.[0]?.value?.trim();
+          const caminho = row.dimensionValues?.[1]?.value ?? "—";
+          return {
+            // Página sem título cai no endereço: melhor um "/plano" do que um
+            // travessão que não diz nada.
+            page: titulo || caminho,
+            path: caminho,
+            views,
+            avgDuration: views === 0 ? 0 : engajamento / views,
+          };
+        }),
       },
     ],
     notices: [],

--- a/tests/integration/connectors.test.ts
+++ b/tests/integration/connectors.test.ts
@@ -667,3 +667,126 @@ describe("GA4 — origem das visitas por UTM", () => {
     expect(tabela?.rows[1]).toMatchObject({ origem: "direto / sem mídia" });
   });
 });
+
+describe("GA4 — duração média", () => {
+  it("pondera pelo volume de cada dia, não é média das médias", async () => {
+    await withCredentials({ ...GOOGLE_OAUTH, GA4_PROPERTY_ID: "123" });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("oauth2.googleapis.com")) {
+          return new Response(JSON.stringify(TOKEN_RESPONSE), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        const corpo = String(init?.body ?? "");
+        if (!corpo.includes('"date"')) {
+          return new Response(JSON.stringify({ rows: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        // Um dia enorme com sessão curta, um dia minúsculo com sessão longa.
+        return new Response(
+          JSON.stringify({
+            rows: [
+              {
+                dimensionValues: [{ value: "20260201" }],
+                metricValues: [
+                  { value: "100" },
+                  { value: "90" },
+                  { value: "0" },
+                  { value: "0" },
+                  { value: "10" },
+                ],
+              },
+              {
+                dimensionValues: [{ value: "20260202" }],
+                metricValues: [
+                  { value: "1" },
+                  { value: "1" },
+                  { value: "0" },
+                  { value: "0" },
+                  { value: "1000" },
+                ],
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }),
+    );
+
+    const { fetchGa4Report } = await import("@/server/connectors/ga4");
+    const report = await fetchGa4Report(RANGE);
+    const duracao = report.kpis.find((k) => k.key === "avgDuration")?.value ?? 0;
+
+    // Ponderado: (100x10 + 1x1000) / 101 = 19,8s.
+    expect(duracao).toBeCloseTo(2000 / 101, 4);
+    // Média das médias daria (10 + 1000) / 2 = 505s — vinte e cinco vezes
+    // maior, e foi o que a tela mostrava antes.
+    expect(duracao).toBeLessThan(100);
+  });
+
+  it("tempo por página vem de engajamento, não da duração da sessão", async () => {
+    await withCredentials({ ...GOOGLE_OAUTH, GA4_PROPERTY_ID: "123" });
+
+    const corpos: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("oauth2.googleapis.com")) {
+          return new Response(JSON.stringify(TOKEN_RESPONSE), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        const corpo = String(init?.body ?? "");
+        corpos.push(corpo);
+        if (!corpo.includes("pageTitle")) {
+          return new Response(JSON.stringify({ rows: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(
+          JSON.stringify({
+            rows: [
+              {
+                dimensionValues: [{ value: "Planos e preços" }, { value: "/planos" }],
+                metricValues: [{ value: "200" }, { value: "9000" }],
+              },
+              {
+                dimensionValues: [{ value: "" }, { value: "/sem-titulo" }],
+                metricValues: [{ value: "10" }, { value: "300" }],
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }),
+    );
+
+    const { fetchGa4Report } = await import("@/server/connectors/ga4");
+    const report = await fetchGa4Report(RANGE);
+    const tabela = report.tables.find((t) => t.title === "Páginas mais vistas");
+
+    // Métrica de sessão cruzada com página devolvia a duração da sessão
+    // inteira, e o número não fechava com o indicador do topo.
+    const pedidos = corpos.join(" ");
+    expect(pedidos).toContain("userEngagementDuration");
+    expect(pedidos).toContain("pageTitle");
+
+    expect(tabela?.rows[0]).toMatchObject({
+      page: "Planos e preços",
+      path: "/planos",
+      avgDuration: 45,
+    });
+    // Página sem título cai no endereço: melhor "/sem-titulo" do que vazio.
+    expect(tabela?.rows[1]).toMatchObject({ page: "/sem-titulo" });
+  });
+});


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia. Reportado por Gessica (Marketing) ao usar a tela: "essa
duração média de cima não bate com a de baixo". Ela estava certa, e o
descasamento denunciava dois defeitos, não um. Abro as Issues correspondentes
(Correção) referenciando este PR.

## O que mudou

### 1. O indicador de duração somava médias

```ts
value: totals.duration / series.length  // média das médias diárias
```

Média não se soma. Um dia com 2 sessões pesava igual a um dia com 200.

**Exemplo real do teste:** 100 sessões de 10s num dia, 1 sessão de 1000s no
outro. O correto é `(100×10 + 1×1000) / 101 = 19,8s`. A tela mostrava
`(10 + 1000) / 2 = 505s` — **vinte e cinco vezes maior**.

Passa a reconstruir o tempo total do dia (média × sessões) e dividir pelo total
de sessões. Como `média_d = tempo_total_d / sessões_d`, a reconstrução é exata,
não aproximação.

### 2. O tempo por página media a sessão inteira

A tabela pedia `averageSessionDuration` cruzado com `pagePath`. Essa é uma
métrica de **sessão**: cruzada com página, devolve a duração das sessões que
passaram por ali — não o tempo gasto naquela página.

Era por isso que os dois números nunca fechariam: mediam coisas diferentes.

Passa a usar `userEngagementDuration ÷ screenPageViews` — tempo de engajamento
por visualização, que é o que a coluna promete.

### 3. Páginas com nome legível

Também pedido pela Gessica: "poderíamos melhorar o que são as páginas?".

`/planos`, `/blog/artigo-3` são endereço, não nome. Entra `pageTitle` como
coluna "Página", e o endereço vira coluna própria. Página sem título cai no
endereço, em vez de virar travessão.

## Como foi validado

- [x] `npm run verify` — **161 testes** (2 novos)
- [x] `npm run test:e2e` — **32/32**
- [x] `npm run build` — compila limpo

**Testes novos:**
1. Ponderação com dois dias de volumes opostos, afirmando o valor exato e que
   ele é menor que a média das médias — sem a segunda asserção, um retorno à
   fórmula antiga passaria despercebido em dados uniformes.
2. Que `userEngagementDuration` e `pageTitle` são efetivamente pedidos, e que
   página sem título cai no endereço.

## Riscos e limitações

**Os números vão mudar na tela, e para menos.** Quem anotou a duração média
antes vai ver outro valor. O anterior é que estava errado.

**`userEngagementDuration` só conta tempo com a aba em foco.** É o
comportamento do GA4 — aba aberta em segundo plano não acumula. O número tende
a ser menor que "tempo na página" de outras ferramentas, e isso é correto, não
defeito.

**`pageTitle` depende do site.** Páginas com título duplicado agregam numa linha
só; páginas com título dinâmico podem se fragmentar. A coluna de endereço
existe para desambiguar.

**Não exercitado contra a propriedade real** — não alcanço o GA4 da Qyra deste
ambiente.

## Próximos passos

- Profundidade de rolagem: o `scroll` nativo do GA4 dispara uma vez só, a 90%.
  Para 25/50/75 é preciso configurar gatilho no GTM; para heatmap de onde a
  pessoa parou, a ferramenta é o Clarity
- Versão da API do Google Ads: o `404` em produção vem de `v18`, descontinuada
- Autenticação (#11) antes do domínio público
- Achados restantes da auditoria: alcance do orgânico e usuários do GA4 ainda
  somados como se fossem aditivos

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_