### PR TITLE
fix: descobre a versão viva da API do Google Ads em vez de fixar uma morta

### DIFF
--- a/docs/integracoes.md
+++ b/docs/integracoes.md
@@ -87,10 +87,27 @@ GOOGLE_REFRESH_TOKEN=1//0g...
 GOOGLE_ADS_DEVELOPER_TOKEN=abcdef...
 GOOGLE_ADS_CUSTOMER_ID=123-456-7890
 GOOGLE_ADS_LOGIN_CUSTOMER_ID=999-888-7777   # o MCC, se o acesso for via gerente
-GOOGLE_ADS_API_VERSION=v18
+GOOGLE_ADS_API_VERSION=                      # opcional, ver abaixo
 ```
 
 Os hífens são removidos pelo conector — pode colar como aparece na interface.
+
+**Sobre a versão da API.** Deixe `GOOGLE_ADS_API_VERSION` vazio: o conector
+desce uma lista de candidatas e usa a primeira que responder.
+
+Isso existe porque o Google publica cerca de três versões por ano e aposenta
+cada uma depois de ~13 meses. Versão aposentada **não devolve erro de API** — a
+URL deixa de existir e a resposta é uma página HTML de 404, que na tela parecia
+problema de token. O painel ficou meses apontando para uma versão morta por
+causa disso.
+
+Para fixar depois de saber qual está viva: abra `/api/diagnostico/google`, veja
+a etapa `ads-versao`, e cadastre o valor que ela reporta. Com a variável
+preenchida o conector obedece e não sonda.
+
+Se a etapa disser que nenhuma candidata respondeu, a lista em
+`VERSOES_CANDIDATAS` (`src/server/connectors/google-ads.ts`) envelheceu e
+precisa de uma versão mais nova.
 
 ### GA4 — específico
 

--- a/src/app/api/diagnostico/google/route.ts
+++ b/src/app/api/diagnostico/google/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-
 import { rangeFromPreset } from "@/lib/date-range";
+import { VERSOES_CANDIDATAS } from "@/server/connectors/google-ads";
 import { getCredentials, getEnv } from "@/server/env";
 import { guard } from "@/server/lib/api";
 import { redactSecrets } from "@/server/lib/http";
@@ -241,12 +241,47 @@ export async function GET(request: Request) {
         cabecalhos["login-customer-id"] = env.GOOGLE_ADS_LOGIN_CUSTOMER_ID.replace(/-/g, "");
       }
 
+      // Versão aposentada não devolve erro de API: a URL some e o Google
+      // responde 404 com página HTML. Descobrir qual responde é o que separa
+      // "token sem permissão" de "estamos chamando um endereço que não existe".
+      let versaoAds: string | null = env.GOOGLE_ADS_API_VERSION ?? null;
+      if (!versaoAds) {
+        for (const candidata of VERSOES_CANDIDATAS) {
+          try {
+            const teste = await fetch(
+              `https://googleads.googleapis.com/${candidata}/customers:listAccessibleCustomers`,
+              { headers: cabecalhos, signal: AbortSignal.timeout(10_000) },
+            );
+            if (teste.status !== 404) {
+              versaoAds = candidata;
+              break;
+            }
+          } catch {
+            // Falha de rede não distingue versão; segue para a próxima.
+          }
+        }
+      }
+
+      etapas.push({
+        etapa: "ads-versao",
+        descricao: "Qual versão da API do Google Ads ainda existe?",
+        status: null,
+        ok: versaoAds !== null,
+        resultado: versaoAds
+          ? `Respondendo em ${versaoAds}.${
+              env.GOOGLE_ADS_API_VERSION
+                ? " Fixada por GOOGLE_ADS_API_VERSION."
+                : " Descoberta automaticamente — cadastre GOOGLE_ADS_API_VERSION com esse valor para fixar."
+            }`
+          : `Nenhuma das versões testadas respondeu (${VERSOES_CANDIDATAS.join(", ")}). A lista de candidatas provavelmente envelheceu.`,
+      });
+
       etapas.push(
         await requisitar(
           "ads-acesso",
           "O developer token é aceito e quais contas ele alcança?",
           {
-            url: `https://googleads.googleapis.com/${env.GOOGLE_ADS_API_VERSION}/customers:listAccessibleCustomers`,
+            url: `https://googleads.googleapis.com/${versaoAds}/customers:listAccessibleCustomers`,
             init: { headers: cabecalhos },
           },
           (d) => {
@@ -273,7 +308,7 @@ export async function GET(request: Request) {
             "ads-consulta",
             "A consulta GAQL do conector responde?",
             {
-              url: `https://googleads.googleapis.com/${env.GOOGLE_ADS_API_VERSION}/customers/${env.GOOGLE_ADS_CUSTOMER_ID.replace(/-/g, "")}/googleAds:searchStream`,
+              url: `https://googleads.googleapis.com/${versaoAds}/customers/${env.GOOGLE_ADS_CUSTOMER_ID.replace(/-/g, "")}/googleAds:searchStream`,
               init: {
                 method: "POST",
                 headers: { ...cabecalhos, "content-type": "application/json" },
@@ -318,7 +353,7 @@ export async function GET(request: Request) {
         analytics: temEscopoAnalytics,
       },
       configuracao: {
-        versaoApiAds: env.GOOGLE_ADS_API_VERSION,
+        versaoApiAds: env.GOOGLE_ADS_API_VERSION ?? "descoberta automaticamente",
         propriedadeGa4: env.GA4_PROPERTY_ID ? mascarar(env.GA4_PROPERTY_ID) : null,
         contaAds: env.GOOGLE_ADS_CUSTOMER_ID ? mascarar(env.GOOGLE_ADS_CUSTOMER_ID) : null,
         usaContaGerente: Boolean(env.GOOGLE_ADS_LOGIN_CUSTOMER_ID),

--- a/src/server/connectors/google-ads.ts
+++ b/src/server/connectors/google-ads.ts
@@ -6,7 +6,7 @@ import type { ChannelReport, DateRange, SeriesPoint } from "@/lib/types";
 import { mockGoogleAds } from "@/mocks/reports";
 import { getCredentials, getEnv, isForceMock } from "@/server/env";
 import { getGoogleAccessToken } from "@/server/lib/google-auth";
-import { type HttpError, httpJson, redactSecrets } from "@/server/lib/http";
+import { HttpError, httpJson, redactSecrets } from "@/server/lib/http";
 import { buildGoogleAdsSnapshotReport } from "./google-ads-snapshot";
 
 /**
@@ -38,6 +38,45 @@ function num(value: string | number | undefined): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+/**
+ * Versões candidatas da API, da mais nova para a mais antiga.
+ *
+ * O Google publica cerca de três por ano e aposenta cada uma depois de ~13
+ * meses. Versão aposentada não devolve erro de API: a URL deixa de existir e a
+ * resposta é uma página HTML de 404. Foi assim que o painel ficou meses
+ * apontando para a `v18` sem ninguém perceber — o erro parecia problema de
+ * token.
+ */
+export const VERSOES_CANDIDATAS = ["v22", "v21", "v20", "v19"];
+
+/** Memoriza a versão que respondeu, para não sondar a cada requisição. */
+let versaoEmUso: string | null = null;
+
+/**
+ * URL inexistente, não erro da API. A Graph do Google devolve 404 com corpo
+ * HTML quando a versão foi aposentada; erro de permissão ou de token vem como
+ * JSON, com outro status.
+ */
+function ehVersaoInexistente(erro: unknown): boolean {
+  return erro instanceof HttpError && erro.status === 404;
+}
+
+/**
+ * Versões a tentar. Com `GOOGLE_ADS_API_VERSION` preenchido, obedece e não
+ * sonda — é assim que se fixa uma versão depois de descobrir qual funciona.
+ */
+function versoesParaTentar(): string[] {
+  const fixada = getEnv().GOOGLE_ADS_API_VERSION;
+  if (fixada) return [fixada];
+  if (versaoEmUso) return [versaoEmUso, ...VERSOES_CANDIDATAS.filter((v) => v !== versaoEmUso)];
+  return VERSOES_CANDIDATAS;
+}
+
+/** Versão que respondeu na última consulta bem-sucedida, para o diagnóstico. */
+export function versaoDaApiEmUso(): string | null {
+  return getEnv().GOOGLE_ADS_API_VERSION ?? versaoEmUso;
+}
+
 async function runQuery(query: string): Promise<GoogleAdsRow[]> {
   const env = getEnv();
   const token = await getGoogleAccessToken();
@@ -52,12 +91,27 @@ async function runQuery(query: string): Promise<GoogleAdsRow[]> {
     headers["login-customer-id"] = env.GOOGLE_ADS_LOGIN_CUSTOMER_ID.replace(/-/g, "");
   }
 
-  const response = await httpJson<SearchStreamResponse>(
-    `https://googleads.googleapis.com/${env.GOOGLE_ADS_API_VERSION}/customers/${customerId}/googleAds:searchStream`,
-    { method: "POST", headers, body: JSON.stringify({ query }) },
-  );
+  const versoes = versoesParaTentar();
+  let ultimoErro: unknown;
 
-  return response.flatMap((chunk) => chunk.results ?? []);
+  for (const versao of versoes) {
+    try {
+      const response = await httpJson<SearchStreamResponse>(
+        `https://googleads.googleapis.com/${versao}/customers/${customerId}/googleAds:searchStream`,
+        { method: "POST", headers, body: JSON.stringify({ query }) },
+      );
+      versaoEmUso = versao;
+      return response.flatMap((chunk) => chunk.results ?? []);
+    } catch (erro) {
+      ultimoErro = erro;
+      // Só 404 significa "esta versão não existe mais". Token recusado,
+      // permissão negada ou conta errada precisam propagar na hora — insistir
+      // em outra versão só transformaria um erro claro em confusão.
+      if (!ehVersaoInexistente(erro)) throw erro;
+    }
+  }
+
+  throw ultimoErro;
 }
 
 /**

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -77,7 +77,10 @@ const schema = z.object({
   GOOGLE_ADS_DEVELOPER_TOKEN: optionalString,
   GOOGLE_ADS_CUSTOMER_ID: optionalString,
   GOOGLE_ADS_LOGIN_CUSTOMER_ID: optionalString,
-  GOOGLE_ADS_API_VERSION: trimmedString("v18"),
+  // Sem padrão fixo de propósito: o Google aposenta uma versão por ano, e
+  // uma constante no código vira 404 silencioso meses depois. Vazio faz o
+  // conector descobrir a versão em uso; preenchido, ele obedece e não testa.
+  GOOGLE_ADS_API_VERSION: optionalString,
 
   GA4_PROPERTY_ID: optionalString,
 

--- a/tests/integration/google-ads-versao.test.ts
+++ b/tests/integration/google-ads-versao.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Descoberta da versão da API do Google Ads.
+ *
+ * Versão aposentada não devolve erro de API: a URL some e o Google responde
+ * 404 com página HTML. O painel ficou meses apontando para a `v18` sem
+ * ninguém perceber, porque o erro parecia problema de token.
+ */
+
+const RANGE = { from: "2026-02-01", to: "2026-02-03" };
+
+const CREDENCIAIS = {
+  GOOGLE_CLIENT_ID: "cid",
+  GOOGLE_CLIENT_SECRET: "secret",
+  GOOGLE_REFRESH_TOKEN: "refresh",
+  GOOGLE_ADS_DEVELOPER_TOKEN: "dev",
+  GOOGLE_ADS_CUSTOMER_ID: "123-456-7890",
+};
+
+const TOKEN = { access_token: "tok", expires_in: 3600, token_type: "Bearer" };
+
+/** Responde 404 para versões antigas e sucesso a partir de `viva`. */
+function googleComVersao(viva: string, urls: string[]) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("oauth2.googleapis.com")) {
+      return new Response(JSON.stringify(TOKEN), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    urls.push(url);
+    if (!url.includes(`/${viva}/`)) {
+      return new Response("<!DOCTYPE html><title>Error 404 (Not Found)</title>", {
+        status: 404,
+        statusText: "Not Found",
+        headers: { "content-type": "text/html" },
+      });
+    }
+    return new Response(JSON.stringify([{ results: [] }]), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+}
+
+async function configurar(vars: Record<string, string>) {
+  vi.resetModules();
+  vi.stubEnv("QYRA_FORCE_MOCK", "false");
+  for (const [k, v] of Object.entries(vars)) vi.stubEnv(k, v);
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe("versão da API do Google Ads", () => {
+  it("desce a lista até achar a versão que ainda existe", async () => {
+    await configurar(CREDENCIAIS);
+    const urls: string[] = [];
+    vi.stubGlobal("fetch", googleComVersao("v20", urls));
+
+    const { fetchGoogleAdsReport, versaoDaApiEmUso } = await import(
+      "@/server/connectors/google-ads"
+    );
+    const report = await fetchGoogleAdsReport(RANGE);
+
+    expect(report.source).toBe("live");
+    expect(versaoDaApiEmUso()).toBe("v20");
+    // Tentou as mais novas antes: a mais recente que responder é a escolhida.
+    expect(urls.some((u) => u.includes("/v22/"))).toBe(true);
+  });
+
+  it("obedece a versão fixada e não sonda", async () => {
+    await configurar({ ...CREDENCIAIS, GOOGLE_ADS_API_VERSION: "v21" });
+    const urls: string[] = [];
+    vi.stubGlobal("fetch", googleComVersao("v21", urls));
+
+    const { fetchGoogleAdsReport } = await import("@/server/connectors/google-ads");
+    await fetchGoogleAdsReport(RANGE);
+
+    // Fixar existe para parar de sondar: nenhuma outra versão pode ser tocada.
+    expect(urls.every((u) => u.includes("/v21/"))).toBe(true);
+  });
+
+  it("erro que não é 404 propaga na hora, sem tentar outra versão", async () => {
+    await configurar(CREDENCIAIS);
+    const urls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("oauth2.googleapis.com")) {
+          return new Response(JSON.stringify(TOKEN), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        urls.push(url);
+        return new Response(JSON.stringify({ error: { message: "USER_PERMISSION_DENIED" } }), {
+          status: 403,
+          statusText: "Forbidden",
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+
+    const { fetchGoogleAdsReport } = await import("@/server/connectors/google-ads");
+    const report = await fetchGoogleAdsReport(RANGE);
+
+    // Cai no snapshot, como qualquer falha — mas sem varrer a lista: insistir
+    // em outra versão transformaria "sem permissão" em confusão.
+    expect(report.source).toBe("snapshot");
+    const versoesTocadas = new Set(
+      urls.map((u) => u.match(/googleapis\.com\/(v\d+)\//)?.[1]).filter(Boolean),
+    );
+    expect(versoesTocadas.size).toBe(1);
+  });
+
+  it("nenhuma versão viva cai no snapshot com aviso, não derruba a tela", async () => {
+    await configurar(CREDENCIAIS);
+    vi.stubGlobal("fetch", googleComVersao("v99", []));
+
+    const { fetchGoogleAdsReport } = await import("@/server/connectors/google-ads");
+    const report = await fetchGoogleAdsReport(RANGE);
+
+    expect(report.source).toBe("snapshot");
+    expect(report.kpis.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — descoberto a partir de um print da tela em produção, onde o
aviso de falha exibia o corpo da resposta do Google. Abro a Issue
correspondente (Correção) referenciando este PR.

## O que mudou

O conector apontava para a **`v18`**, aposentada.

Versão aposentada **não devolve erro de API**: a URL deixa de existir e o
Google responde `404` com uma **página HTML**. Na tela isso apareceu como:

```
A API do Google Ads não respondeu... Detalhe técnico: 404 Not Found em
googleads.googleapis.com — <!DOCTYPE html> <html lang=en> ... Error 404 (Not Found)
```

E passou meses parecendo problema de token. **Mesmo com o developer token
aprovado, a integração ao vivo não subiria.**

### Por que não é só trocar a constante

O Google publica cerca de três versões por ano e aposenta cada uma depois de
~13 meses. Uma constante nova volta a morrer no ano que vem, do mesmo jeito
silencioso.

O conector passa a **descer uma lista de candidatas** e usar a primeira que
responder, memorizando o resultado para não sondar a cada requisição.

### Só `404` dispara a próxima tentativa

Token recusado, permissão negada ou conta errada **propagam na hora**. Insistir
em outra versão transformaria um erro claro em confusão — e mascararia
exatamente o problema que o cliente precisa resolver.

### `GOOGLE_ADS_API_VERSION` vira o jeito de fixar

Perde o padrão. Preenchida, o conector obedece e não sonda. Vazia, ele
descobre.

O diagnóstico ganha a etapa **`ads-versao`**, que reporta qual respondeu e qual
valor cadastrar para fixar. Se nenhuma responder, ela diz isso explicitamente —
em vez de o erro voltar disfarçado de token.

## Como foi validado

- [x] `npm run verify` — **165 testes** (4 novos)
- [x] `npm run test:e2e` — **32/32**
- [x] `npm run build` — compila limpo

**Testes novos**, todos com um servidor falso que responde 404 em HTML para
versões antigas, replicando o comportamento real:

1. Desce a lista até achar a versão viva, tentando as mais novas antes
2. Com a versão fixada, **nenhuma outra é tocada** — fixar existe para parar de sondar
3. Erro que não é 404 não varre a lista: só uma versão é tentada
4. Nenhuma versão viva cai no snapshot com os dados do export, sem derrubar a tela

## Riscos e limitações

**A lista de candidatas foi montada sem acesso à API.** Não alcanço o Google
deste ambiente, então não pude confirmar quais versões estão vivas hoje. Se
nenhuma responder, a etapa `ads-versao` do diagnóstico diz isso — mas o canal
segue no snapshot até alguém atualizar a lista.

**Até 4 requisições na primeira consulta**, se a versão viva for a última da
lista. Depois disso a versão fica memorizada no processo. Em ambiente serverless
cada instância nova sonda de novo — fixar a variável elimina isso.

**A memória é por processo, não compartilhada.** Não há cache entre instâncias.

## Próximos passos

- Cadastrar `GOOGLE_ADS_API_VERSION` com o valor que o diagnóstico reportar
- Aprovação do developer token para acesso básico (aguardando o Google)
- Autenticação (#11) antes do domínio público
- Achados restantes da auditoria: alcance do orgânico e usuários do GA4 ainda
  somados como se fossem aditivos

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_