### PR TITLE
feat: prévia das publicações no orgânico, e corrige o alcance inflado

### DIFF
--- a/src/app/publicacoes/[id]/imagem/route.ts
+++ b/src/app/publicacoes/[id]/imagem/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+
+import { getCredentials, getEnv } from "@/server/env";
+import { httpJson, metaAuthHeaders } from "@/server/lib/http";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 15;
+
+/**
+ * Serve a arte de uma publicação do Instagram pelo próprio domínio.
+ *
+ * Mesma razão do proxy de anúncio: a URL do CDN da Meta carrega token assinado
+ * na query, expira, e a CSP do painel não abre `img-src` para host de
+ * terceiro. Fica fora de `/api` porque o `no-store` global de lá impediria o
+ * navegador de cachear a arte a cada render.
+ */
+
+/** Só dígitos: o ID entra na URL da Graph, e string livre viraria injeção de caminho. */
+const ID_VALIDO = /^\d{1,25}$/;
+
+/** Hosts que a Meta usa para servir mídia do Instagram. */
+const HOSTS_PERMITIDOS = /(^|\.)(cdninstagram\.com|fbcdn\.net|instagram\.com)$/;
+
+interface RespostaDaMidia {
+  media_type?: string;
+  media_url?: string;
+  thumbnail_url?: string;
+}
+
+export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+
+  if (!ID_VALIDO.test(id)) {
+    return NextResponse.json({ erro: "Identificador inválido." }, { status: 400 });
+  }
+  if (!getCredentials().metaOrganic) {
+    return NextResponse.json({ erro: "Orgânico não configurado." }, { status: 404 });
+  }
+
+  const env = getEnv();
+
+  try {
+    const midia = await httpJson<RespostaDaMidia>(
+      `https://graph.facebook.com/${env.META_API_VERSION}/${id}` +
+        "?fields=media_type,media_url,thumbnail_url",
+      { headers: metaAuthHeaders(env.META_ACCESS_TOKEN as string) },
+    );
+
+    // Em vídeo, `media_url` é o arquivo de vídeo — pesado e não renderiza em
+    // `<img>`. O quadro de capa vem em `thumbnail_url`, e é o que serve aqui.
+    const origem =
+      midia.media_type === "VIDEO"
+        ? (midia.thumbnail_url ?? midia.media_url)
+        : (midia.media_url ?? midia.thumbnail_url);
+
+    if (!origem) {
+      return NextResponse.json({ erro: "Publicação sem arte." }, { status: 404 });
+    }
+
+    const destino = new URL(origem);
+    if (destino.protocol !== "https:" || !HOSTS_PERMITIDOS.test(destino.hostname)) {
+      return NextResponse.json({ erro: "Origem da arte não reconhecida." }, { status: 502 });
+    }
+
+    const arte = await fetch(destino, { signal: AbortSignal.timeout(10_000) });
+    if (!arte.ok || !arte.body) {
+      return NextResponse.json({ erro: "Arte indisponível." }, { status: 502 });
+    }
+
+    const tipo = arte.headers.get("content-type") ?? "";
+    if (!tipo.startsWith("image/")) {
+      return NextResponse.json({ erro: "Origem não devolveu imagem." }, { status: 502 });
+    }
+
+    return new NextResponse(arte.body, {
+      headers: {
+        "content-type": tipo,
+        // `private`: é conteúdo da conta do cliente, cacheia no navegador de
+        // quem tem acesso, nunca em intermediário compartilhado.
+        "cache-control": "private, max-age=900",
+        "x-content-type-options": "nosniff",
+      },
+    });
+  } catch {
+    // A arte é enfeite do relatório: falhar aqui devolve 404 e o cartão mostra
+    // o estado sem imagem, nunca um erro que suba para a tela.
+    return NextResponse.json({ erro: "Não foi possível carregar a arte." }, { status: 404 });
+  }
+}

--- a/src/components/report/channel-view.tsx
+++ b/src/components/report/channel-view.tsx
@@ -78,12 +78,10 @@ export function ChannelView({
         <Card className="qy-rise">
           <CardHeader>
             <div>
-              <CardTitle>Melhores criativos</CardTitle>
-              <CardDescription>
-                {report.creatives.some((c) => c.leads > 0)
-                  ? "Ordenados por leads, desempatando pelo menor custo por lead."
-                  : "Sem lead atribuído no período, então a ordem é por investimento."}
-              </CardDescription>
+              <CardTitle>{report.creativesLabel?.title ?? "Melhores criativos"}</CardTitle>
+              {report.creativesLabel?.description ? (
+                <CardDescription>{report.creativesLabel.description}</CardDescription>
+              ) : null}
             </div>
           </CardHeader>
           <CardContent>

--- a/src/components/report/creative-grid.tsx
+++ b/src/components/report/creative-grid.tsx
@@ -5,10 +5,10 @@ import { useState } from "react";
 
 import { cn } from "@/lib/cn";
 import { formatMetric } from "@/lib/format";
-import type { CreativeCard } from "@/lib/types";
+import type { ContentCard } from "@/lib/types";
 
 /** Régua de retenção: quanto do vídeo cada faixa de gente assistiu. */
-function Retencao({ video }: { video: NonNullable<CreativeCard["video"]> }) {
+function Retencao({ video }: { video: NonNullable<ContentCard["video"]> }) {
   const marcas = [
     { rotulo: "25%", valor: video.p25 },
     { rotulo: "50%", valor: video.p50 },
@@ -50,7 +50,7 @@ function Retencao({ video }: { video: NonNullable<CreativeCard["video"]> }) {
   );
 }
 
-function Arte({ criativo }: { criativo: CreativeCard }) {
+function Arte({ criativo }: { criativo: ContentCard }) {
   const [falhou, setFalhou] = useState(false);
 
   if (!criativo.imageUrl || falhou) {
@@ -69,7 +69,7 @@ function Arte({ criativo }: { criativo: CreativeCard }) {
     // biome-ignore lint/performance/noImgElement: servida pelo proxy do próprio domínio
     <img
       src={criativo.imageUrl}
-      alt={`Arte do anúncio ${criativo.name}`}
+      alt={`Arte de ${criativo.title}`}
       loading="lazy"
       decoding="async"
       onError={() => setFalhou(true)}
@@ -84,12 +84,12 @@ function Arte({ criativo }: { criativo: CreativeCard }) {
  * Numa reunião, a pergunta que vem depois de "quanto gastou" é "qual criativo
  * puxou isso" — e ela não se responde com nome de anúncio numa linha de tabela.
  */
-export function CreativeGrid({ criativos }: { criativos: CreativeCard[] }) {
+export function CreativeGrid({ criativos }: { criativos: ContentCard[] }) {
   return (
     <ul className="qy-stagger grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 xl:grid-cols-4">
       {criativos.map((criativo, posicao) => (
         <li
-          key={criativo.id || criativo.name}
+          key={criativo.id || criativo.title}
           className={cn(
             "overflow-hidden rounded-[var(--radius-card)] border border-line bg-surface",
             "transition-[border-color,box-shadow] duration-[var(--duration-base)] ease-[var(--ease-out-soft)]",
@@ -107,32 +107,33 @@ export function CreativeGrid({ criativos }: { criativos: CreativeCard[] }) {
           </div>
 
           <div className="p-3.5">
-            <p className="truncate font-semibold text-ink text-sm" title={criativo.name}>
-              {criativo.name}
-            </p>
-            {criativo.campaign ? (
-              <p className="truncate text-[11px] text-ink-muted" title={criativo.campaign}>
-                {criativo.campaign}
+            {criativo.link ? (
+              <a
+                href={criativo.link}
+                target="_blank"
+                rel="noreferrer"
+                className="block truncate font-semibold text-ink text-sm hover:underline"
+                title={criativo.title}
+              >
+                {criativo.title}
+              </a>
+            ) : (
+              <p className="truncate font-semibold text-ink text-sm" title={criativo.title}>
+                {criativo.title}
+              </p>
+            )}
+            {criativo.subtitle ? (
+              <p className="truncate text-[11px] text-ink-muted" title={criativo.subtitle}>
+                {criativo.subtitle}
               </p>
             ) : null}
 
             <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2">
-              {[
-                { rotulo: "Investimento", valor: criativo.spend, formato: "currency" as const },
-                { rotulo: "Leads", valor: criativo.leads, formato: "integer" as const },
-                { rotulo: "CPL", valor: criativo.cpl, formato: "currency" as const },
-                { rotulo: "CTR", valor: criativo.ctr, formato: "percent" as const },
-                { rotulo: "CPM", valor: criativo.cpm, formato: "currency" as const },
-                {
-                  rotulo: "Impressões",
-                  valor: criativo.impressions,
-                  formato: "integer" as const,
-                },
-              ].map(({ rotulo, valor, formato }) => (
-                <div key={rotulo} className="min-w-0">
-                  <dt className="text-[11px] text-ink-muted leading-tight">{rotulo}</dt>
+              {criativo.metrics.map(({ label, value, format }) => (
+                <div key={label} className="min-w-0">
+                  <dt className="text-[11px] text-ink-muted leading-tight">{label}</dt>
                   <dd className="truncate font-medium text-ink text-sm tabular">
-                    {formatMetric(valor, formato)}
+                    {formatMetric(value, format)}
                   </dd>
                 </div>
               ))}

--- a/src/lib/criativos.ts
+++ b/src/lib/criativos.ts
@@ -1,4 +1,23 @@
-import type { CreativeCard } from "./types";
+/**
+ * Um anúncio com os números que decidem a ordem.
+ *
+ * Separado de `ContentCard` de propósito: o cartão é modelo de tela, com
+ * métricas já rotuladas. A ordenação precisa dos números crus, e é assunto de
+ * anúncio — publicação orgânica se ordena por alcance, não por custo por lead.
+ */
+export interface AdCreative {
+  id: string;
+  name: string;
+  campaign?: string;
+  spend: number;
+  impressions: number;
+  ctr: number;
+  cpm: number;
+  linkClicks: number;
+  leads: number;
+  cpl: number;
+  video?: { reproducoes: number; p25: number; p50: number; p75: number; p100: number };
+}
 
 /**
  * A ordem dos "melhores criativos".
@@ -12,12 +31,14 @@ import type { CreativeCard } from "./types";
  * regra que a legenda anuncia. Quando cada lado ordenava por conta própria, o
  * mock listava na ordem em que os anúncios foram escritos.
  */
-export function ordenarCriativos(criativos: CreativeCard[]): CreativeCard[] {
+export function ordenarCriativos<T extends { leads: number; cpl: number; spend: number }>(
+  criativos: T[],
+): T[] {
   const houveLead = criativos.some((c) => c.leads > 0);
   return [...criativos].sort((a, b) =>
     houveLead ? b.leads - a.leads || a.cpl - b.cpl : b.spend - a.spend,
   );
 }
 
-/** Quantos criativos a tela mostra. Passa disso vira catálogo, não leitura. */
+/** Quantas peças a tela mostra. Passa disso vira catálogo, não leitura. */
 export const MAX_CRIATIVOS = 12;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,28 +77,29 @@ export interface TableBlock {
 }
 
 /**
- * Um anúncio, com a arte. Numa reunião a primeira pergunta depois de "quanto
- * gastou" é "qual criativo puxou isso" — e a resposta é visual.
+ * Uma peça de conteúdo com a arte e alguns números — anúncio ou publicação.
+ *
+ * É modelo de tela, não de domínio: cada conector calcula as métricas que
+ * fazem sentido para ele e as entrega já rotuladas e formatadas. Anúncio fala
+ * em investimento e CPL, publicação fala em alcance e comentários; forçar os
+ * dois no mesmo conjunto de campos deixaria metade vazia dos dois lados.
  */
-export interface CreativeCard {
-  /** ID do anúncio na Meta. É o que o proxy de imagem usa para achar a arte. */
+export interface ContentCard {
   id: string;
-  name: string;
-  campaign?: string;
+  title: string;
+  /** Campanha, no anúncio. Data da publicação, no orgânico. */
+  subtitle?: string;
   /**
    * Caminho no próprio domínio. A arte nunca é linkada direto do CDN da Meta:
    * a URL de lá carrega token assinado na query, e a CSP do painel não abre
    * para host de terceiro.
    */
   imageUrl?: string;
-  spend: number;
-  impressions: number;
-  ctr: number;
-  cpm: number;
-  leads: number;
-  cpl: number;
+  /** Endereço público da peça, quando existe. Abre em nova aba. */
+  link?: string;
+  metrics: Array<{ label: string; value: number; format: MetricFormat }>;
   /**
-   * Retenção deste anúncio, quando ele é vídeo. Retenção agregada da conta não
+   * Retenção desta peça, quando é vídeo. Retenção agregada da conta não
    * responde a pergunta que importa — qual vídeo segura a atenção — porque a
    * média junta o que prende com o que é pulado no primeiro segundo.
    */
@@ -145,8 +146,14 @@ export interface ChannelReport {
   /** Período real dos dados, quando difere do intervalo pedido. */
   periodLabel?: string;
   tables: TableBlock[];
-  /** Anúncios com a arte, quando a origem fornece. Só o Meta Ads preenche. */
-  creatives?: CreativeCard[];
+  /** Peças com a arte, quando a origem fornece: anúncios ou publicações. */
+  creatives?: ContentCard[];
+  /**
+   * Como a seção de peças se chama e por que está nessa ordem. Quem monta os
+   * cartões é quem sabe o critério — a tela não tem como adivinhar se "melhor"
+   * significa custo por lead ou alcance.
+   */
+  creativesLabel?: { title: string; description: string };
   /** Avisos não-fatais: credencial ausente, métrica indisponível, etc. */
   notices: Notice[];
 }

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -219,7 +219,25 @@ export function mockMetaAds(range: DateRange, fetchedAt = NOW): ChannelReport {
             : undefined,
         };
       }),
-    ),
+    ).map((c) => ({
+      id: c.id,
+      title: c.name,
+      subtitle: c.campaign,
+      imageUrl: c.imageUrl,
+      metrics: [
+        { label: "Investimento", value: c.spend, format: "currency" as const },
+        { label: "Leads", value: c.leads, format: "integer" as const },
+        { label: "CPL", value: c.cpl, format: "currency" as const },
+        { label: "CTR", value: c.ctr, format: "percent" as const },
+        { label: "CPM", value: c.cpm, format: "currency" as const },
+        { label: "Impressões", value: c.impressions, format: "integer" as const },
+      ],
+      video: c.video,
+    })),
+    creativesLabel: {
+      title: "Melhores criativos",
+      description: "Ordenados por leads, desempatando pelo menor custo por lead.",
+    },
     tables: [
       {
         title: "Campanhas",
@@ -615,30 +633,36 @@ export function mockOrganico(range: DateRange, fetchedAt = NOW): ChannelReport {
       { key: "reach", label: "Alcance", format: "integer", slot: 1 },
       { key: "engagement", label: "Interações", format: "integer", slot: 2 },
     ],
-    tables: [
-      {
-        title: "Publicações com melhor desempenho",
-        description: "Instagram e Facebook, ordenadas por interações.",
-        columns: [
-          { key: "post", label: "Publicação", align: "left" },
-          { key: "rede", label: "Rede", align: "left" },
-          { key: "reach", label: "Alcance", format: "integer", align: "right" },
-          { key: "engagement", label: "Interações", format: "integer", align: "right" },
-          { key: "rate", label: "Engajamento", format: "percent", align: "right" },
+    creatives: [
+      ["Como funciona a terapia injetável", "Reels · 18/08/2026"],
+      ["5 mitos sobre emagrecimento que você ainda acredita", "Publicação · 15/08/2026"],
+      ["Bastidores da consulta", "Reels · 12/08/2026"],
+      ["Depoimento de paciente", "Publicação · 09/08/2026"],
+      ["Checklist do check-up anual", "Publicação · 06/08/2026"],
+    ].map(([titulo, legenda], i) => {
+      const r = Math.round(reach * [0.14, 0.11, 0.09, 0.06, 0.05][i]);
+      const e = Math.round(engagement * [0.19, 0.15, 0.12, 0.05, 0.07][i]);
+      const curtidas = Math.round(e * 0.84);
+      return {
+        id: `mock-post-${i}`,
+        title: titulo,
+        subtitle: legenda,
+        imageUrl: arteDeDemonstracao(i + 2),
+        metrics: [
+          { label: "Alcance", value: r, format: "integer" as const },
+          { label: "Interações", value: e, format: "integer" as const },
+          { label: "Curtidas", value: curtidas, format: "integer" as const },
+          { label: "Comentários", value: e - curtidas, format: "integer" as const },
+          { label: "Engajamento", value: safeDiv(e, r), format: "percent" as const },
         ],
-        rows: [
-          ["Reels | Como funciona a terapia injetável", "Instagram"],
-          ["Carrossel | 5 mitos sobre emagrecimento", "Instagram"],
-          ["Reels | Bastidores da consulta", "Instagram"],
-          ["Post | Depoimento de paciente", "Facebook"],
-          ["Carrossel | Checklist do check-up", "Instagram"],
-        ].map(([post, rede], i) => {
-          const r = Math.round(reach * [0.14, 0.11, 0.09, 0.06, 0.05][i]);
-          const e = Math.round(engagement * [0.19, 0.15, 0.12, 0.05, 0.07][i]);
-          return { post, rede, reach: r, engagement: e, rate: safeDiv(e, r) };
-        }),
-      },
-    ],
+      };
+    }),
+    creativesLabel: {
+      title: "Publicações com melhor desempenho",
+      description:
+        "Ordenadas por interações. Clique no título para abrir a publicação no Instagram.",
+    },
+    tables: [],
     notices: [],
   };
 }

--- a/src/server/connectors/meta-ads.ts
+++ b/src/server/connectors/meta-ads.ts
@@ -1,9 +1,9 @@
 import { avisoOperacao } from "@/lib/avisos";
 import "server-only";
 
-import { MAX_CRIATIVOS, ordenarCriativos } from "@/lib/criativos";
+import { type AdCreative, MAX_CRIATIVOS, ordenarCriativos } from "@/lib/criativos";
 import { eachDay } from "@/lib/date-range";
-import type { ChannelReport, CreativeCard, DateRange, SeriesPoint } from "@/lib/types";
+import type { ChannelReport, ContentCard, DateRange, SeriesPoint } from "@/lib/types";
 import { mockMetaAds } from "@/mocks/reports";
 import { getCredentials, getEnv, isForceMock } from "@/server/env";
 import { httpJson, metaAuthHeaders } from "@/server/lib/http";
@@ -138,7 +138,7 @@ function somarAcoes(acoes: AcoesDaMeta | undefined): number {
 }
 
 /** Monta os cartões de anúncio. A ordem vem de `ordenarCriativos`. */
-function montarCriativos(porAnuncio: MetaInsightsRow[]): CreativeCard[] {
+function montarCriativos(porAnuncio: MetaInsightsRow[]): ContentCard[] {
   const cartoes = porAnuncio.map((row) => {
     const spend = num(row.spend);
     const impressions = num(row.impressions);
@@ -149,11 +149,11 @@ function montarCriativos(porAnuncio: MetaInsightsRow[]): CreativeCard[] {
       id: row.ad_id ?? "",
       name: row.ad_name ?? "—",
       campaign: row.campaign_name,
-      imageUrl: row.ad_id ? `/criativos/${row.ad_id}/imagem` : undefined,
       spend,
       impressions,
       ctr: impressions === 0 ? 0 : clicks / impressions,
       cpm: impressions === 0 ? 0 : (spend / impressions) * 1000,
+      linkClicks: num(row.inline_link_clicks),
       leads,
       cpl: leads === 0 ? 0 : spend / leads,
       // Sem reprodução não é vídeo — ou é vídeo que ninguém abriu. Nos dois
@@ -168,10 +168,26 @@ function montarCriativos(porAnuncio: MetaInsightsRow[]): CreativeCard[] {
               p100: somarAcoes(row.video_p100_watched_actions) / reproducoes,
             }
           : undefined,
-    } satisfies CreativeCard;
+    } satisfies AdCreative;
   });
 
-  return ordenarCriativos(cartoes).slice(0, MAX_CRIATIVOS);
+  return ordenarCriativos(cartoes)
+    .slice(0, MAX_CRIATIVOS)
+    .map((c) => ({
+      id: c.id,
+      title: c.name,
+      subtitle: c.campaign,
+      imageUrl: c.id ? `/criativos/${c.id}/imagem` : undefined,
+      metrics: [
+        { label: "Investimento", value: c.spend, format: "currency" as const },
+        { label: "Leads", value: c.leads, format: "integer" as const },
+        { label: "CPL", value: c.cpl, format: "currency" as const },
+        { label: "CTR", value: c.ctr, format: "percent" as const },
+        { label: "CPM", value: c.cpm, format: "currency" as const },
+        { label: "Impressões", value: c.impressions, format: "integer" as const },
+      ],
+      video: c.video,
+    }));
 }
 
 export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelReport> {
@@ -323,6 +339,12 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
       { key: "cpm", label: "CPM", format: "currency", slot: 4 },
     ],
     creatives: montarCriativos(porAnuncio),
+    creativesLabel: {
+      title: "Melhores criativos",
+      description: porAnuncio.some((r) => countLeads(r) > 0)
+        ? "Ordenados por leads, desempatando pelo menor custo por lead."
+        : "Sem lead atribuído no período, então a ordem é por investimento.",
+    },
     tables: [
       {
         title: "Campanhas",

--- a/src/server/connectors/organico.ts
+++ b/src/server/connectors/organico.ts
@@ -1,11 +1,12 @@
 import { avisoOperacao } from "@/lib/avisos";
 import "server-only";
 
+import { MAX_CRIATIVOS } from "@/lib/criativos";
 import { eachDay } from "@/lib/date-range";
-import type { ChannelReport, DateRange, Notice, SeriesPoint } from "@/lib/types";
+import type { ChannelReport, ContentCard, DateRange, Notice, SeriesPoint } from "@/lib/types";
 import { mockOrganico } from "@/mocks/reports";
 import { getCredentials, getEnv, isForceMock } from "@/server/env";
-import { httpJson } from "@/server/lib/http";
+import { httpJson, metaAuthHeaders } from "@/server/lib/http";
 
 /**
  * Orgânico de Instagram e Facebook via Graph API (Insights).
@@ -31,6 +32,8 @@ interface MediaResponse {
     media_type?: string;
     permalink?: string;
     timestamp?: string;
+    media_url?: string;
+    thumbnail_url?: string;
     like_count?: number;
     comments_count?: number;
     insights?: { data: Array<{ name: string; values: InsightValue[] }> };
@@ -69,12 +72,47 @@ async function fetchAccountInsights(
 ): Promise<InsightsResponse> {
   const env = getEnv();
   const url = new URL(`https://graph.facebook.com/${env.META_API_VERSION}/${accountId}/insights`);
-  url.searchParams.set("access_token", env.META_ACCESS_TOKEN as string);
   url.searchParams.set("metric", metrics.join(","));
   url.searchParams.set("period", "day");
   url.searchParams.set("since", chunk.from);
   url.searchParams.set("until", addDays(chunk.to, 1));
-  return httpJson<InsightsResponse>(url.toString());
+  // Token no cabeçalho, nunca na query: a Graph ecoa a requisição na mensagem
+  // de erro, e a query string vai parar em log de plataforma.
+  return httpJson<InsightsResponse>(url.toString(), {
+    headers: metaAuthHeaders(env.META_ACCESS_TOKEN as string),
+  });
+}
+
+interface TotalValueResponse {
+  data?: Array<{ name: string; total_value?: { value?: number } }>;
+}
+
+/**
+ * Alcance do período inteiro, com pessoas contadas uma vez só.
+ *
+ * Somar o alcance diário é errado: quem viu na segunda e voltou na quinta
+ * entra duas vezes, e num mês o número infla várias vezes. `total_value` é o
+ * que a própria Meta usa para deduplicar dentro da janela.
+ */
+async function fetchReachTotal(accountId: string, chunk: DateRange): Promise<number | null> {
+  const env = getEnv();
+  const url = new URL(`https://graph.facebook.com/${env.META_API_VERSION}/${accountId}/insights`);
+  url.searchParams.set("metric", "reach");
+  url.searchParams.set("metric_type", "total_value");
+  url.searchParams.set("since", chunk.from);
+  url.searchParams.set("until", addDays(chunk.to, 1));
+
+  try {
+    const resposta = await httpJson<TotalValueResponse>(url.toString(), {
+      headers: metaAuthHeaders(env.META_ACCESS_TOKEN as string),
+    });
+    const valor = resposta.data?.find((m) => m.name === "reach")?.total_value?.value;
+    return typeof valor === "number" ? valor : null;
+  } catch {
+    // Métrica indisponível nesta versão ou conta: quem chama decide o que
+    // fazer, sem derrubar o relatório inteiro por causa de um indicador.
+    return null;
+  }
 }
 
 export async function fetchOrganicoReport(range: DateRange): Promise<ChannelReport> {
@@ -97,9 +135,12 @@ export async function fetchOrganicoReport(range: DateRange): Promise<ChannelRepo
   const notices: Notice[] = [];
 
   const chunks = chunkRange(range);
-  const responses = await Promise.all(
-    chunks.map((chunk) => fetchAccountInsights(accountId, ["reach", "follower_count"], chunk)),
-  );
+  const [responses, totaisDeAlcance] = await Promise.all([
+    Promise.all(
+      chunks.map((chunk) => fetchAccountInsights(accountId, ["reach", "follower_count"], chunk)),
+    ),
+    Promise.all(chunks.map((chunk) => fetchReachTotal(accountId, chunk))),
+  ]);
 
   const reachByDate = new Map<string, number>();
   const followersByDate = new Map<string, number>();
@@ -118,10 +159,11 @@ export async function fetchOrganicoReport(range: DateRange): Promise<ChannelRepo
 
   // Interações vêm da mídia publicada, não do endpoint de conta.
   const mediaUrl = new URL(`https://graph.facebook.com/${env.META_API_VERSION}/${accountId}/media`);
-  mediaUrl.searchParams.set("access_token", env.META_ACCESS_TOKEN as string);
   mediaUrl.searchParams.set(
     "fields",
-    "id,caption,media_type,permalink,timestamp,like_count,comments_count,insights.metric(reach)",
+    // `media_url` é a arte do post; para vídeo ela é o arquivo, e o quadro de
+    // capa vem em `thumbnail_url`. Os dois entram para o cartão ter prévia.
+    "id,caption,media_type,permalink,timestamp,like_count,comments_count,media_url,thumbnail_url,insights.metric(reach)",
   );
   mediaUrl.searchParams.set("since", range.from);
   mediaUrl.searchParams.set("until", addDays(range.to, 1));
@@ -129,7 +171,9 @@ export async function fetchOrganicoReport(range: DateRange): Promise<ChannelRepo
 
   let media: MediaResponse = { data: [] };
   try {
-    media = await httpJson<MediaResponse>(mediaUrl.toString());
+    media = await httpJson<MediaResponse>(mediaUrl.toString(), {
+      headers: metaAuthHeaders(env.META_ACCESS_TOKEN as string),
+    });
   } catch {
     // Insights de mídia dependem de permissão extra; a série de conta continua válida.
     notices.push(
@@ -161,12 +205,70 @@ export async function fetchOrganicoReport(range: DateRange): Promise<ChannelRepo
 
   const totals = series.reduce(
     (acc, p) => ({
-      reach: acc.reach + Number(p.reach),
       engagement: acc.engagement + Number(p.engagement),
       followerGrowth: acc.followerGrowth + Number(p.followerGrowth),
+      // Guardado só para o caso de a métrica deduplicada não vir: soma de
+      // alcance diário conta a mesma pessoa uma vez por dia.
+      alcanceSomado: acc.alcanceSomado + Number(p.reach),
     }),
-    { reach: 0, engagement: 0, followerGrowth: 0 },
+    { engagement: 0, followerGrowth: 0, alcanceSomado: 0 },
   );
+
+  // Cada bloco vem deduplicado pela Meta. Entre blocos não há como deduplicar —
+  // acima de 30 dias o total soma janelas, e o rótulo diz isso.
+  const deduplicado = totaisDeAlcance.every((t) => t !== null);
+  const alcance = deduplicado
+    ? (totaisDeAlcance as number[]).reduce((a, b) => a + b, 0)
+    : totals.alcanceSomado;
+
+  const alcanceExato = deduplicado && chunks.length === 1;
+  const dicaDeAlcance = alcanceExato
+    ? "Pessoas distintas alcançadas no período, contadas uma única vez."
+    : deduplicado
+      ? "A Meta deduplica em janelas de 30 dias. Como o período é maior, quem apareceu em dois meses conta duas vezes."
+      : "Soma do alcance diário: quem voltou em dias diferentes conta uma vez por dia. A métrica deduplicada não veio da Meta.";
+
+  /**
+   * As publicações como cartão, com a arte.
+   *
+   * Mesma pergunta do lado pago, outra métrica: aqui "melhor" é o que
+   * engajou, não o que custou menos. A imagem passa pelo proxio do próprio
+   * domínio — a URL do CDN da Meta expira e a CSP do painel não abre para
+   * host de terceiro.
+   */
+  const publicacoes: ContentCard[] = media.data
+    .map((item) => {
+      const reach = scalar(item.insights?.data?.[0]?.values?.[0]?.value ?? 0);
+      const curtidas = item.like_count ?? 0;
+      const comentarios = item.comments_count ?? 0;
+      const engagement = curtidas + comentarios;
+      return { item, reach, curtidas, comentarios, engagement };
+    })
+    .sort((a, b) => b.engagement - a.engagement)
+    .slice(0, MAX_CRIATIVOS)
+    .map(({ item, reach, curtidas, comentarios, engagement }) => ({
+      id: item.id,
+      title: (item.caption ?? "Sem legenda").slice(0, 70),
+      subtitle: [
+        item.media_type === "VIDEO" ? "Reels" : "Publicação",
+        item.timestamp?.slice(0, 10).split("-").reverse().join("/"),
+      ]
+        .filter(Boolean)
+        .join(" · "),
+      imageUrl: `/publicacoes/${item.id}/imagem`,
+      link: item.permalink,
+      metrics: [
+        { label: "Alcance", value: reach, format: "integer" as const },
+        { label: "Interações", value: engagement, format: "integer" as const },
+        { label: "Curtidas", value: curtidas, format: "integer" as const },
+        { label: "Comentários", value: comentarios, format: "integer" as const },
+        {
+          label: "Engajamento",
+          value: reach === 0 ? 0 : engagement / reach,
+          format: "percent" as const,
+        },
+      ],
+    }));
 
   return {
     channel: "organico",
@@ -175,13 +277,14 @@ export async function fetchOrganicoReport(range: DateRange): Promise<ChannelRepo
     range,
     fetchedAt: new Date().toISOString(),
     kpis: [
-      { key: "reach", label: "Alcance", value: totals.reach, format: "integer" },
+      { key: "reach", label: "Alcance", value: alcance, format: "integer", hint: dicaDeAlcance },
       { key: "engagement", label: "Interações", value: totals.engagement, format: "integer" },
       {
         key: "engagementRate",
         label: "Taxa de engajamento",
-        value: totals.reach === 0 ? 0 : totals.engagement / totals.reach,
+        value: alcance === 0 ? 0 : totals.engagement / alcance,
         format: "percent",
+        hint: "Interações divididas pelo alcance. Com alcance inflado o denominador cresce e a taxa cai — por isso ele é deduplicado antes.",
       },
       {
         key: "followerGrowth",
@@ -195,33 +298,13 @@ export async function fetchOrganicoReport(range: DateRange): Promise<ChannelRepo
       { key: "reach", label: "Alcance", format: "integer", slot: 1 },
       { key: "engagement", label: "Interações", format: "integer", slot: 2 },
     ],
-    tables: [
-      {
-        title: "Publicações com melhor desempenho",
-        description: "Ordenadas por interações no período.",
-        columns: [
-          { key: "post", label: "Publicação", align: "left" },
-          { key: "rede", label: "Rede", align: "left" },
-          { key: "reach", label: "Alcance", format: "integer", align: "right" },
-          { key: "engagement", label: "Interações", format: "integer", align: "right" },
-          { key: "rate", label: "Engajamento", format: "percent", align: "right" },
-        ],
-        rows: media.data
-          .map((item) => {
-            const reach = scalar(item.insights?.data?.[0]?.values?.[0]?.value ?? 0);
-            const engagement = (item.like_count ?? 0) + (item.comments_count ?? 0);
-            return {
-              post: (item.caption ?? "Sem legenda").slice(0, 80),
-              rede: item.media_type === "VIDEO" ? "Instagram · Reels" : "Instagram",
-              reach,
-              engagement,
-              rate: reach === 0 ? 0 : engagement / reach,
-            };
-          })
-          .sort((a, b) => b.engagement - a.engagement)
-          .slice(0, 15),
-      },
-    ],
+    creatives: publicacoes,
+    creativesLabel: {
+      title: "Publicações com melhor desempenho",
+      description:
+        "Ordenadas por interações. Clique no título para abrir a publicação no Instagram.",
+    },
+    tables: [],
     notices,
   };
 }

--- a/tests/integration/connectors.test.ts
+++ b/tests/integration/connectors.test.ts
@@ -391,7 +391,9 @@ describe("Orgânico", () => {
 
     const insightCalls: string[] = [];
     mockFetch((url) => {
-      if (url.includes("/insights")) {
+      // Só a consulta diária conta janela: a do alcance deduplicado
+      // (`total_value`) acompanha os mesmos blocos e dobraria a contagem.
+      if (url.includes("/insights") && !url.includes("metric_type=total_value")) {
         insightCalls.push(url);
         return { data: [{ name: "reach", period: "day", values: [] }] };
       }

--- a/tests/integration/organico-alcance.test.ts
+++ b/tests/integration/organico-alcance.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Alcance do orgânico.
+ *
+ * Alcance conta pessoas distintas. Somar o valor diário conta de novo quem
+ * voltou — num mês o número infla várias vezes, e a taxa de engajamento afunda
+ * junto porque o alcance é o denominador.
+ */
+
+const CREDENCIAIS = {
+  META_ACCESS_TOKEN: "token",
+  META_AD_ACCOUNT_ID: "123",
+  META_PAGE_ID: "999",
+  META_IG_USER_ID: "888",
+};
+
+/** 3 dias, 100 de alcance cada, mas só 120 pessoas distintas no total. */
+function grafo({ comTotalValue }: { comTotalValue: boolean }) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    if (url.includes("metric_type=total_value")) {
+      if (!comTotalValue) {
+        return new Response(JSON.stringify({ error: { message: "unsupported metric" } }), {
+          status: 400,
+          statusText: "Bad Request",
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({ data: [{ name: "reach", total_value: { value: 120 } }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    if (url.includes("/insights")) {
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              name: "reach",
+              period: "day",
+              values: [
+                { value: 100, end_time: "2026-02-02T07:00:00+0000" },
+                { value: 100, end_time: "2026-02-03T07:00:00+0000" },
+                { value: 100, end_time: "2026-02-04T07:00:00+0000" },
+              ],
+            },
+            { name: "follower_count", period: "day", values: [] },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    return new Response(JSON.stringify({ data: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+}
+
+async function relatorio() {
+  const { fetchOrganicoReport } = await import("@/server/connectors/organico");
+  return fetchOrganicoReport({ from: "2026-02-01", to: "2026-02-03" });
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+  vi.stubEnv("QYRA_FORCE_MOCK", "false");
+  for (const [k, v] of Object.entries(CREDENCIAIS)) vi.stubEnv(k, v);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe("alcance do orgânico", () => {
+  it("usa o valor deduplicado da Meta, não a soma dos dias", async () => {
+    vi.stubGlobal("fetch", grafo({ comTotalValue: true }));
+    const report = await relatorio();
+
+    // Soma diária daria 300. Pessoas distintas são 120.
+    expect(report.kpis.find((k) => k.key === "reach")?.value).toBe(120);
+  });
+
+  it("a taxa de engajamento usa o alcance deduplicado como base", async () => {
+    vi.stubGlobal("fetch", grafo({ comTotalValue: true }));
+    const report = await relatorio();
+
+    const alcance = report.kpis.find((k) => k.key === "reach")?.value ?? 0;
+    const interacoes = report.kpis.find((k) => k.key === "engagement")?.value ?? 0;
+    const taxa = report.kpis.find((k) => k.key === "engagementRate")?.value ?? 0;
+
+    // Com o alcance inflado o denominador cresce e a taxa afunda sem motivo.
+    expect(taxa).toBeCloseTo(alcance === 0 ? 0 : interacoes / alcance, 6);
+  });
+
+  it("sem a métrica deduplicada, soma os dias mas avisa na dica", async () => {
+    vi.stubGlobal("fetch", grafo({ comTotalValue: false }));
+    const report = await relatorio();
+    const kpi = report.kpis.find((k) => k.key === "reach");
+
+    expect(kpi?.value).toBe(300);
+    // Número inflado sem aviso é pior que número inflado com aviso.
+    expect(kpi?.hint).toMatch(/uma vez por dia/i);
+  });
+
+  it("não põe o token na URL", async () => {
+    const espiao = grafo({ comTotalValue: true });
+    vi.stubGlobal("fetch", espiao);
+    await relatorio();
+
+    // A Graph ecoa a requisição na mensagem de erro, e query string vai
+    // parar em log de plataforma.
+    for (const chamada of espiao.mock.calls) {
+      const url = String(chamada[0]);
+      expect(url).not.toContain("access_token");
+    }
+  });
+});

--- a/tests/unit/criativos.test.ts
+++ b/tests/unit/criativos.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import { ordenarCriativos } from "@/lib/criativos";
-import type { CreativeCard } from "@/lib/types";
+import { type AdCreative, ordenarCriativos } from "@/lib/criativos";
 
-function criativo(parcial: Partial<CreativeCard> & { name: string }): CreativeCard {
+function criativo(parcial: Partial<AdCreative> & { name: string }): AdCreative {
   return {
     id: parcial.name,
     spend: 0,
     impressions: 0,
     ctr: 0,
     cpm: 0,
+    linkClicks: 0,
     leads: 0,
     cpl: 0,
     ...parcial,


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — o canal orgânico acabou de entrar no ar e a pergunta veio
direta: "no orgânico tem como puxar os criativos também, preview?". Os dois
defeitos abaixo só se tornaram visíveis agora. Abro as Issues correspondentes
referenciando este PR.

## O que mudou

### 1. O alcance somava os dias (Correção)

Alcance conta **pessoas distintas**. O código somava o valor diário: quem viu
na segunda e voltou na quinta entrava duas vezes. Num mês, o número inflava
várias vezes.

Pior: a **taxa de engajamento afundava junto**, porque o alcance é o
denominador. Duas métricas erradas pelo mesmo motivo.

Passa a pedir a métrica deduplicada da Meta (`metric_type=total_value`), com a
soma diária como último recurso. Quando cai no recurso, a dica do indicador
**diz** que o número conta uma pessoa uma vez por dia.

A Meta deduplica em janelas de 30 dias. Acima disso o total soma janelas, e a
dica muda para dizer exatamente isso — em vez de prometer precisão que não tem.

### 2. Publicações com prévia (Nova função)

As publicações viram cartões com a arte, como os criativos do lado pago. Mesma
pergunta, outra métrica: aqui "melhor" é o que engajou, não o que custou menos.
Alcance, interações, curtidas, comentários e taxa. **Título abre o post no
Instagram.**

A tabela de texto saiu — era a mesma informação, sem a arte.

### 3. O cartão deixou de ser específico de anúncio (Melhoria)

`ContentCard` carrega uma lista de métricas **já rotuladas**, e cada conector
decide as suas: investimento e CPL de um lado, alcance e comentários do outro.
Forçar os dois no mesmo conjunto de campos deixaria metade vazia dos dois lados.

A ordenação continua separada: `AdCreative` é o que a regra de anúncio ordena
(leads, depois CPL); publicação se ordena por interações. `creativesLabel` no
relatório deixa cada conector nomear a seção e explicar o critério — a tela não
tem como adivinhar se "melhor" significa custo por lead ou alcance.

### 4. Token fora da query string (Correção de segurança)

O conector do orgânico mandava `access_token` na URL em duas chamadas,
incluindo a de publicações. Passa para o cabeçalho `Authorization`, como já era
no Meta Ads. A Graph ecoa a requisição na mensagem de erro, e query string vai
parar em log de plataforma.

Novo proxy `/publicacoes/<id>/imagem`, com as mesmas travas do de anúncios: só
ID numérico, só host da Meta/Instagram, só `content-type` de imagem, qualquer
falha vira 404 com o cartão mostrando o estado sem arte. Em vídeo serve o
`thumbnail_url` — `media_url` é o arquivo de vídeo e não renderiza em `<img>`.

## Como foi validado

- [x] `npm run verify` — **169 testes** (4 novos)
- [x] `npm run test:e2e` — **32/32**
- [x] `npm run build` — compila limpo
- [x] Captura da grade renderizada em 1440px

**Testes novos:** o alcance usa o valor deduplicado e não a soma (300 → 120 no
cenário do teste); a taxa de engajamento usa a mesma base; sem a métrica
deduplicada, soma **e avisa na dica**; e nenhuma chamada leva `access_token` na
URL — este último pegou a chamada de publicações, que eu tinha deixado passar.

## Riscos e limitações

**`metric_type=total_value` não foi exercitado contra a conta real.** Se a Meta
não devolver, o conector cai na soma e avisa — não quebra, mas o número volta a
ser o inflado, agora rotulado.

**O alcance vai cair na tela, e bastante.** Quem anotou o número antes vai ver
outro. O anterior é que estava errado.

**Acima de 30 dias o total soma janelas.** É o limite da API, não da
implementação. A dica declara.

**A tabela de texto saiu.** Quem exportava ou lia por ali perde o formato —
a informação está nos cartões, mas em outro formato.

## Próximos passos

- Conferir alcance e prévia contra a conta real agora que o canal está ligado
- Usuários do GA4 ainda somados como se fossem aditivos — mesmo defeito, outro canal
- Autenticação (#11) antes do domínio público

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_