### PR TITLE
feat: arte inteira nos cartões e botão para abrir a peça

### DIFF
--- a/src/components/report/creative-grid.tsx
+++ b/src/components/report/creative-grid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ImageOff } from "lucide-react";
+import { ExternalLink, ImageOff, Play } from "lucide-react";
 import { useState } from "react";
 
 import { cn } from "@/lib/cn";
@@ -50,31 +50,83 @@ function Retencao({ video }: { video: NonNullable<ContentCard["video"]> }) {
   );
 }
 
+/**
+ * A arte inteira, sem corte.
+ *
+ * `object-cover` num quadro fixo decapitava Reels: 9:16 dentro de 5:4 perde
+ * mais da metade da peça, e o que sobra costuma ser o meio do vídeo — sem
+ * a headline, que é justamente o que se quer avaliar.
+ *
+ * `object-contain` mostra tudo, e a mesma imagem desfocada preenche o fundo
+ * para a sobra não virar barra preta. É o mesmo arquivo, então o navegador
+ * baixa uma vez só.
+ */
 function Arte({ criativo }: { criativo: ContentCard }) {
   const [falhou, setFalhou] = useState(false);
+  const ehVideo = criativo.video !== undefined;
 
   if (!criativo.imageUrl || falhou) {
     return (
-      <div className="flex aspect-[5/4] items-center justify-center bg-surface-sunken">
+      <div className="flex aspect-[4/5] items-center justify-center bg-surface-sunken">
         <ImageOff className="size-6 text-ink-muted" aria-hidden="true" />
         <span className="sr-only">Arte indisponível</span>
       </div>
     );
   }
 
+  const arte = (
+    <div className="relative aspect-[4/5] w-full overflow-hidden bg-plum-800">
+      {/* Fundo: mesma imagem, borrada e ampliada. Preenche a sobra sem
+          inventar cor e sem competir com a peça. */}
+      {/* biome-ignore lint/performance/noImgElement: servida pelo proxy do próprio domínio */}
+      <img
+        src={criativo.imageUrl}
+        alt=""
+        aria-hidden="true"
+        loading="lazy"
+        decoding="async"
+        className="absolute inset-0 size-full scale-110 object-cover blur-xl saturate-150"
+      />
+      {/* biome-ignore lint/performance/noImgElement: servida pelo proxy do próprio domínio */}
+      <img
+        src={criativo.imageUrl}
+        alt={`Arte de ${criativo.title}`}
+        loading="lazy"
+        decoding="async"
+        onError={() => setFalhou(true)}
+        className="relative size-full object-contain"
+      />
+
+      {ehVideo ? (
+        <span
+          className="absolute right-2 bottom-2 flex items-center gap-1 rounded-full bg-plum-800/85 px-2 py-1 font-medium text-[10px] text-white"
+          aria-hidden="true"
+        >
+          <Play className="size-3 fill-current" />
+          vídeo
+        </span>
+      ) : null}
+    </div>
+  );
+
+  if (!criativo.link) return arte;
+
   return (
-    // `img` puro, não `next/image`: a arte é servida pela própria rota de
-    // proxy, já dimensionada pela Meta, e o otimizador só acrescentaria um
-    // segundo salto para o mesmo byte.
-    // biome-ignore lint/performance/noImgElement: servida pelo proxy do próprio domínio
-    <img
-      src={criativo.imageUrl}
-      alt={`Arte de ${criativo.title}`}
-      loading="lazy"
-      decoding="async"
-      onError={() => setFalhou(true)}
-      className="aspect-[5/4] w-full bg-surface-sunken object-cover"
-    />
+    <a
+      href={criativo.link}
+      target="_blank"
+      rel="noreferrer"
+      className="group/arte relative block"
+      aria-label={`${criativo.linkLabel ?? "Abrir peça"}: ${criativo.title}`}
+    >
+      {arte}
+      <span className="absolute inset-0 flex items-center justify-center bg-plum-800/0 opacity-0 transition-[background-color,opacity] duration-[var(--duration-base)] group-hover/arte:bg-plum-800/55 group-hover/arte:opacity-100">
+        <span className="flex items-center gap-1.5 rounded-full bg-white/95 px-3 py-1.5 font-medium text-[11px] text-plum-800">
+          <ExternalLink className="size-3.5" aria-hidden="true" />
+          {criativo.linkLabel ?? "Abrir"}
+        </span>
+      </span>
+    </a>
   );
 }
 
@@ -140,6 +192,26 @@ export function CreativeGrid({ criativos }: { criativos: ContentCard[] }) {
             </dl>
 
             {criativo.video ? <Retencao video={criativo.video} /> : null}
+
+            {/* Botão explícito: o link no título passava despercebido, e o
+                overlay da arte só aparece no hover — que não existe no celular. */}
+            {criativo.link ? (
+              <a
+                href={criativo.link}
+                target="_blank"
+                rel="noreferrer"
+                className={cn(
+                  "mt-3 flex w-full items-center justify-center gap-1.5 rounded-full",
+                  "border border-line-strong bg-surface px-3 py-2",
+                  "font-medium text-[11px] text-ink-secondary",
+                  "transition-colors duration-[var(--duration-fast)]",
+                  "hover:bg-surface-sunken hover:text-ink",
+                )}
+              >
+                <ExternalLink className="size-3.5" aria-hidden="true" />
+                {criativo.linkLabel ?? "Abrir peça"}
+              </a>
+            ) : null}
           </div>
         </li>
       ))}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -97,6 +97,10 @@ export interface ContentCard {
   imageUrl?: string;
   /** Endereço público da peça, quando existe. Abre em nova aba. */
   link?: string;
+  /** Texto do botão que abre o link. "Ver no Instagram", "Ver anúncio". */
+  linkLabel?: string;
+  /** Proporção da arte, quando conhecida — evita cortar Reels em quadro largo. */
+  aspectRatio?: number;
   metrics: Array<{ label: string; value: number; format: MetricFormat }>;
   /**
    * Retenção desta peça, quando é vídeo. Retenção agregada da conta não

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -202,6 +202,8 @@ export function mockMetaAds(range: DateRange, fetchedAt = NOW): ChannelReport {
           name: nome as string,
           campaign: campanha as string,
           imageUrl: arteDeDemonstracao(i),
+          link: "https://www.facebook.com/ads/library/",
+          linkLabel: "Ver anúncio",
           spend: Math.round(s * 100) / 100,
           impressions: impr,
           ctr: 0.006 + noise(`meta-ctr-criativo-${i}`) * 0.038,
@@ -648,6 +650,18 @@ export function mockOrganico(range: DateRange, fetchedAt = NOW): ChannelReport {
         title: titulo,
         subtitle: legenda,
         imageUrl: arteDeDemonstracao(i + 2),
+        link: "https://www.instagram.com/qyra.saude/",
+        linkLabel: "Ver no Instagram",
+        // Reels tem vídeo; publicação estática não.
+        video: (legenda as string).startsWith("Reels")
+          ? {
+              reproducoes: Math.round(r * 0.72),
+              p25: 0.44,
+              p50: 0.26,
+              p75: 0.15,
+              p100: 0.08,
+            }
+          : undefined,
         metrics: [
           { label: "Alcance", value: r, format: "integer" as const },
           { label: "Interações", value: e, format: "integer" as const },
@@ -660,7 +674,7 @@ export function mockOrganico(range: DateRange, fetchedAt = NOW): ChannelReport {
     creativesLabel: {
       title: "Publicações com melhor desempenho",
       description:
-        "Ordenadas por interações. Clique no título para abrir a publicação no Instagram.",
+        "Ordenadas por interações. O botão em cada cartão abre a publicação no Instagram.",
     },
     tables: [],
     notices: [],

--- a/src/server/connectors/meta-ads.ts
+++ b/src/server/connectors/meta-ads.ts
@@ -137,8 +137,40 @@ function somarAcoes(acoes: AcoesDaMeta | undefined): number {
   return (acoes ?? []).reduce((total, item) => total + num(item.value), 0);
 }
 
+interface AdsEdgeResponse {
+  data?: Array<{ id: string; preview_shareable_link?: string }>;
+}
+
+/**
+ * Link de pré-visualização de cada anúncio, por ID.
+ *
+ * A Insights não devolve isso — é a borda `/ads` da conta. Enriquecimento
+ * puro: sem ele o cartão continua completo, só não abre a peça.
+ */
+async function buscarLinksDeAnuncio(): Promise<Map<string, string>> {
+  const env = getEnv();
+  const url = new URL(
+    `https://graph.facebook.com/${env.META_API_VERSION}/act_${(env.META_AD_ACCOUNT_ID as string).replace(/^act_/, "")}/ads`,
+  );
+  url.searchParams.set("fields", "id,preview_shareable_link");
+  url.searchParams.set("limit", "200");
+
+  try {
+    const resposta = await httpJson<AdsEdgeResponse>(url.toString(), {
+      headers: metaAuthHeaders(env.META_ACCESS_TOKEN as string),
+    });
+    return new Map(
+      (resposta.data ?? [])
+        .filter((a) => a.preview_shareable_link)
+        .map((a) => [a.id, a.preview_shareable_link as string]),
+    );
+  } catch {
+    return new Map();
+  }
+}
+
 /** Monta os cartões de anúncio. A ordem vem de `ordenarCriativos`. */
-function montarCriativos(porAnuncio: MetaInsightsRow[]): ContentCard[] {
+function montarCriativos(porAnuncio: MetaInsightsRow[], links: Map<string, string>): ContentCard[] {
   const cartoes = porAnuncio.map((row) => {
     const spend = num(row.spend);
     const impressions = num(row.impressions);
@@ -178,6 +210,8 @@ function montarCriativos(porAnuncio: MetaInsightsRow[]): ContentCard[] {
       title: c.name,
       subtitle: c.campaign,
       imageUrl: c.id ? `/criativos/${c.id}/imagem` : undefined,
+      link: links.get(c.id),
+      linkLabel: "Ver anúncio",
       metrics: [
         { label: "Investimento", value: c.spend, format: "currency" as const },
         { label: "Leads", value: c.leads, format: "integer" as const },
@@ -205,7 +239,7 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
     return report;
   }
 
-  const [daily, byCampaign, porAnuncio] = await Promise.all([
+  const [daily, byCampaign, porAnuncio, linksDeAnuncio] = await Promise.all([
     fetchInsights(range, {
       fields: CAMPOS_DE_METRICA,
       time_increment: "1",
@@ -222,6 +256,7 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
       fields: `ad_id,ad_name,campaign_name,${CAMPOS_DE_METRICA}`,
       level: "ad",
     }).catch(() => [] as MetaInsightsRow[]),
+    buscarLinksDeAnuncio(),
   ]);
 
   // A API omite dias sem entrega; a série precisa deles para não "pular" no eixo.
@@ -338,7 +373,7 @@ export async function fetchMetaAdsReport(range: DateRange): Promise<ChannelRepor
       { key: "impressions", label: "Impressões", format: "integer", slot: 3 },
       { key: "cpm", label: "CPM", format: "currency", slot: 4 },
     ],
-    creatives: montarCriativos(porAnuncio),
+    creatives: montarCriativos(porAnuncio, linksDeAnuncio),
     creativesLabel: {
       title: "Melhores criativos",
       description: porAnuncio.some((r) => countLeads(r) > 0)

--- a/src/server/connectors/organico.ts
+++ b/src/server/connectors/organico.ts
@@ -257,6 +257,7 @@ export async function fetchOrganicoReport(range: DateRange): Promise<ChannelRepo
         .join(" · "),
       imageUrl: `/publicacoes/${item.id}/imagem`,
       link: item.permalink,
+      linkLabel: "Ver no Instagram",
       metrics: [
         { label: "Alcance", value: reach, format: "integer" as const },
         { label: "Interações", value: engagement, format: "integer" as const },
@@ -302,7 +303,7 @@ export async function fetchOrganicoReport(range: DateRange): Promise<ChannelRepo
     creativesLabel: {
       title: "Publicações com melhor desempenho",
       description:
-        "Ordenadas por interações. Clique no título para abrir a publicação no Instagram.",
+        "Ordenadas por interações. O botão em cada cartão abre a publicação no Instagram.",
     },
     tables: [],
     notices,


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — pedido direto ao ver a tela: "preciso que a imagem apareça
inteira ou que tenha algum botão para conseguir ver o post e o vídeo". Vale
para os dois canais. Abro a Issue correspondente (Melhoria) referenciando este
PR.

## O que mudou

### A arte estava sendo cortada

`object-cover` num quadro 5:4 **decapita um Reels de 9:16**: some mais da
metade da peça, e o que sobra costuma ser o meio do vídeo — sem a headline, que
é justamente o que se quer avaliar num relatório de criativo.

Agora:
- Quadro **4:5**, que serve melhor tanto 1:1 quanto 9:16
- **`object-contain`** — a peça aparece inteira, nada é cortado
- A **mesma imagem, desfocada e ampliada**, preenche a sobra. Mesmo arquivo,
  então o navegador baixa uma vez só, e a borda não vira barra preta

### Abrir a peça deixa de ser adivinhação

Antes o único caminho era descobrir que o título era clicável — a legenda dizia
"clique no título", e ninguém lê legenda.

- **Botão no rodapé de cada cartão**: "Ver no Instagram" / "Ver anúncio"
- **Sobreposição na arte** ao passar o mouse

O botão existe porque **hover não existe no celular**. A sobreposição sozinha
deixaria metade dos usuários sem acesso.

### No Meta Ads o link nem existia

Só o orgânico tinha `permalink`. Entra **`preview_shareable_link`**, da borda
`/ads` da conta — a Insights não devolve isso, é uma chamada à parte.

Enriquecimento puro: falha nessa chamada deixa o cartão completo, só sem o
botão.

### Selo de vídeo

Cartão de vídeo ganha um selo, para separar Reels de publicação estática antes
de o leitor chegar na régua de retenção.

## Como foi validado

- [x] `npm run verify` — **169 testes**
- [x] `npm run test:e2e` — **32/32**
- [x] `npm run build` — compila limpo
- [x] Captura em 1440px, tema escuro, no estado normal **e** no hover

## Riscos e limitações

**`preview_shareable_link` não foi exercitado contra a API real** — não alcanço
a Meta deste ambiente. Se o campo não vier, o cartão fica sem o botão em vez de
quebrar. É também mais uma chamada por relatório na tela do Meta Ads.

**O link do Meta abre a pré-visualização da Meta, não o post público.** Para
anúncio isso é o esperado, mas exige estar logado numa conta com acesso — não
serve para mandar para o cliente.

**Peças muito estreitas ou muito largas ainda sobram no quadro.** O fundo
desfocado disfarça, mas um criativo 16:9 dentro de 4:5 fica com faixa
considerável acima e abaixo.

**O limite de 200 anúncios** na busca de links é fixo. Conta com mais que isso
pode ter cartão sem botão, sem aviso na tela.

## Próximos passos

- Conferir contra a conta real se o botão do Meta Ads aparece
- Autenticação (#11) antes do domínio público
- Achados restantes da auditoria: usuários do GA4 ainda somados como se fossem
  aditivos

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_