### PR TITLE
fix: health checa as duas variáveis do Google Ads que faltavam

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -25,6 +25,13 @@ const CONFIGURAVEIS = [
   "GOOGLE_REFRESH_TOKEN",
   "GOOGLE_ADS_DEVELOPER_TOKEN",
   "GOOGLE_ADS_CUSTOMER_ID",
+  // Opcionais, mas invisíveis se não estiverem aqui: quem cadastra não tem
+  // como confirmar que colaram, e ficam fora tanto de "presentes" quanto de
+  // "ausentes". Ausência é legítima nas duas — a de login só é necessária
+  // quando o acesso é via conta gerente, e a de versão só para fixar o que o
+  // conector já descobre sozinho.
+  "GOOGLE_ADS_LOGIN_CUSTOMER_ID",
+  "GOOGLE_ADS_API_VERSION",
   "GA4_PROPERTY_ID",
   "QYRA_FORCE_MOCK",
 ] as const;


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — descoberto ao conferir uma saída real de `/api/health`
durante a configuração do domínio. Abro a Issue correspondente (Correção)
referenciando este PR.

## O que mudou

`GOOGLE_ADS_LOGIN_CUSTOMER_ID` e `GOOGLE_ADS_API_VERSION` não estavam na lista
de variáveis que o endpoint inspeciona. Consequência: não apareciam **nem em
`variaveisPresentes` nem em `variaveisAusentes`** — sumiam do relatório.

Quem cadastrava o login-customer-id não tinha como confirmar que o valor colou.
É exatamente o problema que o endpoint existe para responder, e é a mesma classe
de erro que já custou horas nesta configuração — quando um valor foi colado no
campo de nota da Vercel em vez do campo de valor.

## Sobre ausência ser legítima

As duas são opcionais, e aparecer em `variaveisAusentes` não é alarme:

- **`GOOGLE_ADS_LOGIN_CUSTOMER_ID`** só é necessária quando o acesso à conta é
  via conta gerente (MCC)
- **`GOOGLE_ADS_API_VERSION`** só serve para fixar a versão que o conector já
  descobre sozinho

O endpoint reporta o fato; `docs/integracoes.md` diz quando cada uma importa.

## Como foi validado

- [x] `npm run verify` — **174 testes**
- [x] `npm run build` — compila limpo

## Riscos e limitações

**Duas linhas novas em `variaveisAusentes` para quem não usa MCC.** Pode passar
a impressão de configuração incompleta em instalação que está correta. O
documento cobre, mas o JSON sozinho não distingue "opcional ausente" de
"obrigatória faltando".

**A lista continua manual.** Uma variável nova em `env.ts` não entra aqui
sozinha — foi assim que estas duas ficaram de fora.

## Próximos passos

- Autenticação (#11): o painel está público em `dashboard.qyra.com.br` sem senha
- Achados restantes da auditoria: usuários do GA4 ainda somados como se fossem
  aditivos

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_