### PR TITLE
feat: Comportamento vira tela própria, no padrão dos canais

### DIFF
--- a/src/app/_shared/channel-page.tsx
+++ b/src/app/_shared/channel-page.tsx
@@ -1,10 +1,9 @@
 import { DateRangePicker } from "@/components/layout/date-range-picker";
 import { ChannelView } from "@/components/report/channel-view";
-import { ClarityPanel } from "@/components/report/clarity-panel";
 import { getChannel } from "@/lib/channels";
 import { parseRange } from "@/lib/date-range";
 import type { ChannelId } from "@/lib/types";
-import { getChannelReport, getClarityResumo } from "@/server/reports";
+import { getChannelReport } from "@/server/reports";
 
 export interface ChannelPageProps {
   searchParams: Promise<{ preset?: string; from?: string; to?: string }>;
@@ -28,19 +27,13 @@ export async function ChannelPage({
   const meta = getChannel(channel);
   const { range, preset } = parseRange(await searchParams);
 
-  // O Clarity só complementa a tela do Analytics, e é opcional: sem token, sem
-  // seção. A busca vai em paralelo para não somar latência ao relatório.
-  const [report, clarity] = await Promise.all([
-    getChannelReport(channel, range),
-    channel === "ga4" ? getClarityResumo() : Promise.resolve(null),
-  ]);
+  const report = await getChannelReport(channel, range);
 
   return (
     <ChannelView
       report={report}
       description={meta.description}
       actions={<DateRangePicker range={range} preset={preset} />}
-      extra={clarity ? <ClarityPanel resumo={clarity} /> : null}
     />
   );
 }

--- a/src/app/comportamento/page.tsx
+++ b/src/app/comportamento/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+
+import { PageHeader } from "@/components/layout/page-header";
+import { ClarityPanel } from "@/components/report/clarity-panel";
+import { EmptyState } from "@/components/ui/empty-state";
+import { getClarityResumo } from "@/server/reports";
+
+export const metadata: Metadata = { title: "Comportamento" };
+
+/**
+ * Sem isto o Next pré-renderiza esta rota na compilação — ela não lê
+ * `searchParams`, então nada a marca como dinâmica sozinha. O HTML nasceria
+ * com o estado do build, quando não há credencial, e serviria "não
+ * configurado" para sempre.
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+/**
+ * Comportamento na página.
+ *
+ * Tela própria, e não uma seção do Analytics, porque a pergunta é outra: o
+ * Analytics responde quantos vieram e de onde; aqui é o que fizeram depois de
+ * chegar. Juntas na mesma tela, a segunda ficava no rodapé da primeira — o
+ * lugar que ninguém rola até.
+ */
+export default async function Page() {
+  const resumo = await getClarityResumo();
+
+  return (
+    <div className="space-y-5 sm:space-y-6">
+      <PageHeader
+        title="Comportamento"
+        description="Até onde as pessoas leem e onde a página não responde — pelo Microsoft Clarity"
+      />
+
+      {resumo ? (
+        <ClarityPanel resumo={resumo} />
+      ) : (
+        <EmptyState
+          title="Clarity não configurado"
+          description="Cadastre CLARITY_API_TOKEN e CLARITY_PROJECT_ID para esta tela ler os dados de rolagem e atrito. Sem eles não há o que mostrar."
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LayoutGrid } from "lucide-react";
+import { LayoutGrid, MousePointerClick } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 
@@ -19,6 +19,9 @@ import { cn } from "@/lib/cn";
 const NAV = [
   { href: "/", label: "Visão geral", icon: LayoutGrid, slot: null },
   ...CHANNELS.map((c) => ({ href: c.href, label: c.label, icon: null, slot: c.slot })),
+  // Fora de CHANNELS de propósito: não é canal de aquisição e não produz
+  // relatório de período — é o que acontece depois que a pessoa chega.
+  { href: "/comportamento", label: "Comportamento", icon: MousePointerClick, slot: null },
 ];
 
 export function Sidebar({ className }: { className?: string }) {

--- a/src/components/report/channel-view.tsx
+++ b/src/components/report/channel-view.tsx
@@ -20,13 +20,10 @@ export function ChannelView({
   report,
   description,
   actions,
-  extra,
 }: {
   report: ChannelReport;
   description: string;
   actions?: React.ReactNode;
-  /** Seção de outra origem, abaixo das tabelas. Hoje só o Clarity usa. */
-  extra?: React.ReactNode;
 }) {
   const [primary, ...rest] = report.kpis;
 
@@ -106,8 +103,6 @@ export function ChannelView({
           </CardContent>
         </Card>
       ))}
-
-      {extra}
     </div>
   );
 }

--- a/src/components/report/clarity-panel.tsx
+++ b/src/components/report/clarity-panel.tsx
@@ -1,15 +1,23 @@
-import { ExternalLink, MousePointerClick, TriangleAlert, Undo2 } from "lucide-react";
+import { TriangleAlert } from "lucide-react";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { cn } from "@/lib/cn";
+import { DataTable } from "@/components/ui/data-table";
+import { StatTile } from "@/components/ui/stat-tile";
 import { formatMetric } from "@/lib/format";
-import type { ClarityResumo } from "@/lib/types";
+import type { ClarityResumo, Kpi } from "@/lib/types";
+
+/** Abaixo disso a página não é lida — é aberta e abandonada. */
+const LIMITE_DE_ABANDONO = 0.4;
 
 /**
- * Régua de rolagem de uma página.
+ * Régua de rolagem.
  *
- * A barra é a leitura de relance — bate o olho e vê que a página é abandonada
- * na primeira dobra. O número ao lado é a conferência.
+ * Profundidade é magnitude, não estado: a barra usa **uma cor só**, e quem
+ * varia é o comprimento. Pintar a barra por faixa transformaria uma medida
+ * contínua em julgamento de bom/ruim, e cor sozinha não informa.
+ *
+ * O julgamento existe, mas vem escrito: página abaixo do limite ganha um selo
+ * com ícone e texto, que sobrevive a daltonismo, impressão e alto contraste.
  */
 function Rolagem({
   pagina,
@@ -21,157 +29,186 @@ function Rolagem({
   sessoes: number;
 }) {
   const pct = Math.min(100, Math.max(0, rolagem * 100));
-
-  // Abaixo de 40% a página não é lida, é abandonada. A cor diz isso antes de
-  // o número ser lido — mas nunca sozinha: o valor está sempre ao lado.
-  const tom = pct < 40 ? "bg-negative" : pct < 65 ? "bg-warning" : "bg-accent";
+  const abandonada = rolagem < LIMITE_DE_ABANDONO;
 
   return (
-    <li className="grid grid-cols-[1fr_auto] items-baseline gap-x-3 gap-y-1 py-2">
-      <p className="min-w-0 truncate text-ink text-sm" title={pagina}>
-        {pagina}
-      </p>
-      <p className="text-[11px] text-ink-muted tabular">
-        {formatMetric(sessoes, "integer")} sessões
-      </p>
-      <div className="col-span-2 flex items-center gap-2">
-        <div className="h-2 min-w-0 flex-1 overflow-hidden rounded-full bg-surface-sunken">
-          <div className={cn("h-full rounded-full", tom)} style={{ width: `${pct}%` }} />
+    <li className="py-2.5">
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="min-w-0 truncate text-ink text-sm" title={pagina}>
+          {pagina}
+        </p>
+        <p className="shrink-0 text-[11px] text-ink-muted tabular">
+          {formatMetric(sessoes, "integer")} sessões
+        </p>
+      </div>
+
+      <div className="mt-1.5 flex items-center gap-2.5">
+        <div
+          className="h-2 min-w-0 flex-1 overflow-hidden rounded-full bg-surface-sunken"
+          role="img"
+          aria-label={`${formatMetric(rolagem, "percent")} da página percorrida`}
+        >
+          <div
+            className="h-full rounded-full bg-[var(--color-series-3)]"
+            style={{ width: `${pct}%` }}
+          />
         </div>
         <p className="w-12 shrink-0 text-right font-medium text-ink text-xs tabular">
           {formatMetric(rolagem, "percent")}
         </p>
       </div>
+
+      {abandonada ? (
+        <p className="mt-1.5 flex items-center gap-1 text-[11px] text-warning">
+          <TriangleAlert className="size-3 shrink-0" aria-hidden="true" />
+          Abandonada antes da metade
+        </p>
+      ) : null}
     </li>
   );
 }
 
-function Atrito({
-  icone: Icone,
-  rotulo,
-  valor,
-  explicacao,
-}: {
-  icone: typeof MousePointerClick;
-  rotulo: string;
-  valor: number;
-  explicacao: string;
-}) {
-  return (
-    <div className="rounded-2xl border border-line bg-surface-sunken/40 p-3.5">
-      <div className="flex items-center gap-1.5">
-        <Icone className="size-3.5 text-ink-muted" aria-hidden="true" />
-        <p className="font-medium text-[11px] text-ink-secondary">{rotulo}</p>
-      </div>
-      <p className="mt-2 font-semibold text-ink text-xl tabular">
-        {formatMetric(valor, "integer")}
-      </p>
-      <p className="mt-1 text-[11px] text-ink-muted leading-snug">{explicacao}</p>
-    </div>
-  );
+function indicadores(resumo: ClarityResumo): Kpi[] {
+  return [
+    {
+      key: "rolagem",
+      label: "Rolagem média",
+      value: resumo.rolagemMedia,
+      format: "percent",
+      hint: "Quanto da página, em média, as pessoas percorreram antes de sair.",
+    },
+    { key: "sessoes", label: "Sessões", value: resumo.sessoes, format: "integer" },
+    {
+      key: "mortos",
+      label: "Cliques mortos",
+      value: resumo.cliquesMortos,
+      format: "integer",
+      lowerIsBetter: true,
+      hint: "Clicou em algo que não era clicável.",
+    },
+    {
+      key: "raiva",
+      label: "Cliques de raiva",
+      value: resumo.cliquesDeRaiva,
+      format: "integer",
+      lowerIsBetter: true,
+      hint: "Clicou várias vezes no mesmo ponto, sem resposta.",
+    },
+    {
+      key: "voltas",
+      label: "Voltas rápidas",
+      value: resumo.voltasRapidas,
+      format: "integer",
+      lowerIsBetter: true,
+      hint: "Abriu e voltou na hora — não era o que esperava.",
+    },
+    {
+      key: "erros",
+      label: "Erros de script",
+      value: resumo.errosDeScript,
+      format: "integer",
+      lowerIsBetter: true,
+      hint: "Algo quebrou no navegador de quem visitou.",
+    },
+  ];
 }
 
 /**
  * Comportamento na página, pelo Clarity.
  *
- * O GA4 responde quantos vieram e de onde. Esta seção responde o que fizeram
- * depois de chegar — até onde rolaram, onde clicaram no que não era clicável,
- * onde desistiram.
+ * Segue a composição das telas de canal — indicadores, um visual, uma tabela —
+ * porque quem abre esta tela vem das outras e não deveria reaprender a ler.
  */
 export function ClarityPanel({ resumo }: { resumo: ClarityResumo }) {
+  const [principal, ...resto] = indicadores(resumo);
   const paginas = resumo.porPagina.slice(0, 8);
-  const linkProjeto = resumo.projeto
-    ? `https://clarity.microsoft.com/projects/view/${resumo.projeto}`
-    : null;
 
   return (
-    <Card className="qy-rise">
-      <CardHeader>
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="min-w-0">
-            <CardTitle>Comportamento na página</CardTitle>
+    <>
+      <section
+        aria-label="Indicadores"
+        className="grid grid-cols-2 gap-3 qy-stagger [&>*:last-child:nth-child(odd)]:col-span-2 sm:gap-4 lg:grid-cols-[repeat(auto-fit,minmax(11rem,1fr))] lg:[&>*:last-child:nth-child(odd)]:col-span-1"
+      >
+        {principal ? <StatTile kpi={principal} emphasis /> : null}
+        {resto.map((kpi) => (
+          <StatTile key={kpi.key} kpi={kpi} />
+        ))}
+      </section>
+
+      <Card className="qy-rise">
+        <CardHeader>
+          <div>
+            <CardTitle>Até onde as pessoas rolam</CardTitle>
             <CardDescription>
-              Últimos {resumo.dias} dias — é a janela máxima que o Clarity devolve por API. Não
-              acompanha o filtro de datas acima.
+              Ordenado por sessões. A barra é a fração da página percorrida — quanto mais curta,
+              mais cedo a leitura para.
             </CardDescription>
           </div>
-          {linkProjeto ? (
-            <a
-              href={`${linkProjeto}/heatmaps`}
-              target="_blank"
-              rel="noreferrer"
-              className={cn(
-                "flex shrink-0 items-center gap-1.5 rounded-full border border-line-strong",
-                "bg-surface px-3 py-1.5 font-medium text-[11px] text-ink-secondary",
-                "transition-colors duration-[var(--duration-fast)] hover:bg-surface-sunken hover:text-ink",
-              )}
-            >
-              <ExternalLink className="size-3.5" aria-hidden="true" />
-              Mapas de calor
-            </a>
-          ) : null}
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-5">
-        <div>
-          <div className="flex items-baseline justify-between gap-3">
-            <p className="font-medium text-ink text-sm">Até onde as pessoas rolam</p>
-            <p className="text-[11px] text-ink-muted tabular">
-              média {formatMetric(resumo.rolagemMedia, "percent")}
-            </p>
-          </div>
+        </CardHeader>
+        <CardContent>
           {paginas.length === 0 ? (
-            <p className="mt-2 text-ink-muted text-xs">
+            <p className="text-ink-muted text-xs">
               Sem dado de rolagem no período. O Clarity precisa de tráfego recente para medir.
             </p>
           ) : (
-            <ul className="mt-1 divide-y divide-line/60">
+            <ul className="divide-y divide-line/60">
               {paginas.map((linha) => (
                 <Rolagem
-                  key={String(linha.pagina)}
-                  pagina={String(linha.pagina)}
-                  rolagem={Number(linha.rolagem)}
-                  sessoes={Number(linha.sessoes)}
+                  key={linha.pagina}
+                  pagina={linha.pagina}
+                  rolagem={linha.rolagem}
+                  sessoes={linha.sessoes}
                 />
               ))}
             </ul>
           )}
-        </div>
+        </CardContent>
+      </Card>
 
-        <div>
-          <p className="font-medium text-ink text-sm">Sinais de atrito</p>
-          <p className="text-[11px] text-ink-muted">
-            Onde a pessoa tentou algo e a página não respondeu.
-          </p>
-          <div className="mt-2.5 grid grid-cols-2 gap-2.5 lg:grid-cols-4">
-            <Atrito
-              icone={MousePointerClick}
-              rotulo="Cliques mortos"
-              valor={resumo.cliquesMortos}
-              explicacao="Clicou em algo que não era clicável."
-            />
-            <Atrito
-              icone={MousePointerClick}
-              rotulo="Cliques de raiva"
-              valor={resumo.cliquesDeRaiva}
-              explicacao="Clicou várias vezes no mesmo ponto, sem resposta."
-            />
-            <Atrito
-              icone={Undo2}
-              rotulo="Voltas rápidas"
-              valor={resumo.voltasRapidas}
-              explicacao="Abriu e voltou na hora — não era o que esperava."
-            />
-            <Atrito
-              icone={TriangleAlert}
-              rotulo="Erros de script"
-              valor={resumo.errosDeScript}
-              explicacao="Algo quebrou no navegador de quem visitou."
-            />
+      <Card className="qy-rise">
+        <CardHeader>
+          <div>
+            <CardTitle>Atrito por página</CardTitle>
+            <CardDescription>
+              Onde a pessoa tentou algo e a página não respondeu. Ordene por qualquer coluna para
+              achar a que mais irrita.
+            </CardDescription>
           </div>
-        </div>
-      </CardContent>
-    </Card>
+        </CardHeader>
+        <CardContent className="px-2">
+          <DataTable
+            block={{
+              title: "Atrito por página",
+              columns: [
+                { key: "pagina", label: "Página", align: "left" },
+                { key: "sessoes", label: "Sessões", format: "integer", align: "right" },
+                { key: "rolagem", label: "Rolagem", format: "percent", align: "right" },
+                {
+                  key: "cliquesMortos",
+                  label: "Cliques mortos",
+                  format: "integer",
+                  align: "right",
+                },
+                {
+                  key: "cliquesDeRaiva",
+                  label: "Cliques de raiva",
+                  format: "integer",
+                  align: "right",
+                },
+              ],
+              rows: resumo.porPagina.map((l) => ({ ...l })),
+              ...(resumo.projeto
+                ? {
+                    action: {
+                      label: "Mapas de calor no Clarity",
+                      href: `https://clarity.microsoft.com/projects/view/${resumo.projeto}/heatmaps`,
+                    },
+                  }
+                : {}),
+            }}
+          />
+        </CardContent>
+      </Card>
+    </>
   );
 }

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowDown, ArrowUp } from "lucide-react";
+import { ArrowDown, ArrowUp, ExternalLink } from "lucide-react";
 import { useId, useMemo, useState } from "react";
 
 import { cn } from "@/lib/cn";
@@ -81,6 +81,27 @@ export function DataTable({ block, className }: { block: TableBlock; className?:
 
   return (
     <div className={className}>
+      {/* Atalho para fora do painel. Fica antes da tabela e alinhado à direita,
+          longe do fluxo de leitura dos números — quem veio ler o dado não
+          esbarra nele, quem quer sair encontra sem procurar. */}
+      {block.action ? (
+        <div className="flex justify-end pb-2">
+          <a
+            href={block.action.href}
+            target="_blank"
+            rel="noreferrer"
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full border border-line-strong",
+              "bg-surface px-3 py-1.5 font-medium text-[11px] text-ink-secondary",
+              "transition-colors duration-[var(--duration-fast)] hover:bg-surface-sunken hover:text-ink",
+            )}
+          >
+            <ExternalLink className="size-3.5" aria-hidden="true" />
+            {block.action.label}
+          </a>
+        </div>
+      ) : null}
+
       {/* No celular não há cabeçalho para clicar, e ordenar é justamente como
           se acha a campanha que mais gastou. Um `select` nativo abre o picker
           do sistema — melhor que qualquer popover custom nesse tamanho de tela. */}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -134,7 +134,13 @@ export interface ClarityResumo {
   voltasRapidas: number;
   errosDeScript: number;
   /** Rolagem por página, para a régua visual. */
-  porPagina: Array<{ pagina: string; rolagem: number; sessoes: number }>;
+  porPagina: Array<{
+    pagina: string;
+    rolagem: number;
+    sessoes: number;
+    cliquesMortos: number;
+    cliquesDeRaiva: number;
+  }>;
   /** Dias efetivamente cobertos — a API limita, o pedido não manda. */
   dias: number;
   /** ID do projeto, para os atalhos. */

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -691,12 +691,13 @@ export function mockOrganico(range: DateRange, fetchedAt = NOW): ChannelReport {
  * a leitura.
  */
 export function mockClarity(): ClarityResumo {
+  // página, rolagem, fatia das sessões, cliques mortos, cliques de raiva
   const paginas = [
-    ["/", 0.71, 0.42],
-    ["/planos", 0.38, 0.21],
-    ["/terapia-injetavel", 0.62, 0.16],
-    ["/agendar", 0.84, 0.13],
-    ["/sobre", 0.29, 0.08],
+    ["/", 0.71, 0.42, 62, 8],
+    ["/planos", 0.38, 0.21, 94, 19],
+    ["/terapia-injetavel", 0.62, 0.16, 21, 3],
+    ["/agendar", 0.84, 0.13, 31, 6],
+    ["/sobre", 0.29, 0.08, 6, 1],
   ] as const;
 
   const sessoes = 1_840;
@@ -708,10 +709,12 @@ export function mockClarity(): ClarityResumo {
     cliquesDeRaiva: 37,
     voltasRapidas: 96,
     errosDeScript: 12,
-    porPagina: paginas.map(([pagina, rolagem, fatia]) => ({
+    porPagina: paginas.map(([pagina, rolagem, fatia, cliquesMortos, cliquesDeRaiva]) => ({
       pagina,
       rolagem,
       sessoes: Math.round(sessoes * fatia),
+      cliquesMortos,
+      cliquesDeRaiva,
     })),
     dias: 3,
     projeto: "y5l8wdf890",

--- a/src/server/connectors/clarity.ts
+++ b/src/server/connectors/clarity.ts
@@ -106,6 +106,10 @@ export async function fetchClarityResumo(): Promise<ClarityResumo | null> {
       trafegoPorPagina.map((linha) => [String(linha.URL ?? ""), num(linha.totalSessionCount)]),
     );
 
+    /** Índice de uma métrica de atrito por URL, montado sob demanda. */
+    const atritoPorPagina = (nome: string) =>
+      new Map(metrica(porUrl, nome).map((l) => [String(l.URL ?? ""), num(l.subTotal)]));
+
     return {
       // A API devolve a profundidade em porcentagem (0-100); a tela trabalha
       // em fração, como todo percentual do painel.
@@ -122,6 +126,10 @@ export async function fetchClarityResumo(): Promise<ClarityResumo | null> {
             pagina,
             rolagem: num(linha.averageScrollDepth) / 100,
             sessoes: visitasPorPagina.get(pagina) ?? 0,
+            // A resposta por URL já traz todas as métricas — pedir só rolagem e
+            // descartar o resto gastaria a mesma cota por menos informação.
+            cliquesMortos: atritoPorPagina("DeadClickCount").get(pagina) ?? 0,
+            cliquesDeRaiva: atritoPorPagina("RageClickCount").get(pagina) ?? 0,
           };
         })
         .sort((a, b) => Number(b.sessoes) - Number(a.sessoes)),


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — pedido direto: separar o comportamento numa aba própria e
deixá-lo no mesmo acabamento das outras telas. Abro a Issue correspondente
(Melhoria) referenciando este PR.

## O que mudou

### Tela própria

A seção ficava no rodapé do Analytics — o lugar que ninguém rola até. E a
pergunta é outra: o Analytics responde **quantos vieram e de onde**; esta tela
responde **o que fizeram depois de chegar**.

Ganha entrada na navegação, **fora de `CHANNELS` de propósito**: não é canal de
aquisição e não produz relatório de período, então não tem cor de série nem
filtro de datas.

### Composição igual à dos canais

Indicadores, um visual, uma tabela — quem chega aqui vem das outras telas e não
deveria reaprender a ler.

| Bloco | Conteúdo |
|---|---|
| Indicadores | Rolagem média, sessões e os quatro sinais de atrito, cada um com dica explicando a métrica |
| Barras | Profundidade de rolagem por página, ordenada por sessões |
| Tabela | Atrito por página, ordenável, com atalho para os mapas de calor |

## Duas correções que a convenção de visualização exige

**A barra pintava por faixa** — vermelho abaixo de 40%, amarelo até 65%, lilás
acima. Profundidade de rolagem é **magnitude, não estado**: transformar medida
contínua em julgamento de bom/ruim pelo matiz é exatamente o que a convenção do
projeto proíbe.

Agora é **uma cor só**, e quem varia é o comprimento. O julgamento continua
existindo, mas **escrito**: página abaixo de 40% ganha selo com ícone e texto —
que sobrevive a daltonismo, impressão e alto contraste, coisa que cor sozinha
não faz.

**O atrito por página vinha de graça** na mesma resposta da API e estava sendo
descartado. Pedir só rolagem gastava a mesma cota por menos informação.

## Dois bugs pegos na conferência

**A rota nasceu estática.** Ela não lê `searchParams`, então nada a marcava como
dinâmica, e o Next pré-renderizou o HTML **na compilação** — quando não existe
credencial. A página serviria "Clarity não configurado" para sempre, em
produção inclusive. Resolvido com `dynamic = "force-dynamic"`.

**O `action` da tabela existia no tipo mas nunca fora renderizado.** O botão dos
mapas de calor não aparecia em lugar nenhum — nem aqui, nem no "Páginas mais
vistas" do Analytics, onde eu já o tinha declarado.

## Como foi validado

- [x] `npm run verify` — **180 testes**
- [x] `npm run test:e2e` — **32/32**
- [x] `npm run build` — a rota aparece como `ƒ` (dinâmica), não `○`
- [x] Captura em 1440px escuro e 390px, com checagem programática de estouro de texto
- [x] Link do Clarity conferido no HTML servido, com o ID correto

## Riscos e limitações

**Seis indicadores deixam um sozinho na segunda linha** em telas largas. É o
mesmo comportamento das outras telas com contagem ímpar, mas aqui fica mais
visível por serem poucos.

**A tela não tem filtro de datas** e nem deveria: a API do Clarity devolve no
máximo 3 dias. Mas ela fica ao lado de telas que têm filtro, e isso é uma
assimetria que pode confundir.

**Nada exercitado contra a API real.** Os nomes das métricas e dos campos são os
documentados. Se divergirem, a tela mostra zeros em vez de quebrar.

## Próximos passos

- Conferir contra a resposta real do Clarity e ajustar nomes se divergirem
- Autenticação (#11): o painel está público em `dashboard.qyra.com.br` sem senha
- Achados restantes da auditoria: usuários do GA4 ainda somados como se fossem
  aditivos

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_