### PR TITLE
fix: usuários do GA4 deixam de ser somados dia a dia

### DIFF
--- a/src/server/connectors/ga4.ts
+++ b/src/server/connectors/ga4.ts
@@ -77,7 +77,7 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
 
   const dateRanges = [{ startDate: range.from, endDate: range.to }];
 
-  const [daily, byChannel, byPage, byUtm] = await Promise.all([
+  const [daily, byChannel, byPage, byUtm, totalDoPeriodo] = await Promise.all([
     runReport({
       dateRanges,
       dimensions: [{ name: "date" }],
@@ -132,6 +132,10 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
       orderBys: [{ metric: { metricName: "sessions" }, desc: true }],
       limit: 40,
     }),
+    // Usuário é pessoa distinta, e pessoa não se soma: quem entrou segunda e
+    // voltou quinta apareceria duas vezes. Sem a dimensão de data, o GA4
+    // deduplica dentro da janela pedida — é a única forma de ter o número certo.
+    runReport({ dateRanges, metrics: [{ name: "totalUsers" }] }),
   ]);
 
   const byDate = new Map(
@@ -170,6 +174,10 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
     { sessions: 0, users: 0, conversions: 0, duration: 0 },
   );
 
+  // `totals.users` é a soma diária e continua servindo de rede: se a consulta
+  // sem dimensão não vier, é melhor um número inflado que um zero.
+  const usuariosDoPeriodo = num(totalDoPeriodo.rows?.[0]?.metricValues?.[0]?.value) || totals.users;
+
   return {
     channel: "ga4",
     label: "Google Analytics",
@@ -178,7 +186,13 @@ export async function fetchGa4Report(range: DateRange): Promise<ChannelReport> {
     fetchedAt: new Date().toISOString(),
     kpis: [
       { key: "sessions", label: "Sessões", value: totals.sessions, format: "integer" },
-      { key: "users", label: "Usuários", value: totals.users, format: "integer" },
+      {
+        key: "users",
+        label: "Usuários",
+        value: usuariosDoPeriodo,
+        format: "integer",
+        hint: "Pessoas distintas no período, contadas uma única vez. Somar o total de cada dia contaria de novo quem voltou.",
+      },
       { key: "conversions", label: "Conversões", value: totals.conversions, format: "integer" },
       {
         key: "conversionRate",

--- a/tests/integration/connectors.test.ts
+++ b/tests/integration/connectors.test.ts
@@ -792,3 +792,113 @@ describe("GA4 — duração média", () => {
     expect(tabela?.rows[1]).toMatchObject({ page: "/sem-titulo" });
   });
 });
+
+describe("GA4 — usuários", () => {
+  it("usa o total deduplicado do período, não a soma dos dias", async () => {
+    await withCredentials({ ...GOOGLE_OAUTH, GA4_PROPERTY_ID: "123" });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("oauth2.googleapis.com")) {
+          return new Response(JSON.stringify(TOKEN_RESPONSE), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        const corpo = String(init?.body ?? "");
+
+        // A consulta sem dimensão é a que devolve o número deduplicado.
+        if (!corpo.includes('"dimensions"')) {
+          return new Response(JSON.stringify({ rows: [{ metricValues: [{ value: "120" }] }] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (!corpo.includes('"date"')) {
+          return new Response(JSON.stringify({ rows: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        // Três dias com 100 usuários cada — em grande parte os mesmos.
+        return new Response(
+          JSON.stringify({
+            rows: ["20260201", "20260202", "20260203"].map((d) => ({
+              dimensionValues: [{ value: d }],
+              metricValues: [
+                { value: "150" },
+                { value: "100" },
+                { value: "0" },
+                { value: "0" },
+                { value: "60" },
+              ],
+            })),
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }),
+    );
+
+    const { fetchGa4Report } = await import("@/server/connectors/ga4");
+    const report = await fetchGa4Report(RANGE);
+
+    // Soma diária daria 300. Pessoas distintas são 120.
+    expect(report.kpis.find((k) => k.key === "users")?.value).toBe(120);
+    // Sessão é aditiva e continua somando: 150 x 3.
+    expect(report.kpis.find((k) => k.key === "sessions")?.value).toBe(450);
+  });
+
+  it("sem o total deduplicado, cai na soma — inflado é melhor que zero", async () => {
+    await withCredentials({ ...GOOGLE_OAUTH, GA4_PROPERTY_ID: "123" });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("oauth2.googleapis.com")) {
+          return new Response(JSON.stringify(TOKEN_RESPONSE), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        const corpo = String(init?.body ?? "");
+        if (!corpo.includes('"dimensions"')) {
+          return new Response(JSON.stringify({ rows: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (!corpo.includes('"date"')) {
+          return new Response(JSON.stringify({ rows: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(
+          JSON.stringify({
+            rows: [
+              {
+                dimensionValues: [{ value: "20260201" }],
+                metricValues: [
+                  { value: "10" },
+                  { value: "7" },
+                  { value: "0" },
+                  { value: "0" },
+                  { value: "0" },
+                ],
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }),
+    );
+
+    const { fetchGa4Report } = await import("@/server/connectors/ga4");
+    const report = await fetchGa4Report(RANGE);
+
+    expect(report.kpis.find((k) => k.key === "users")?.value).toBe(7);
+  });
+});


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — é o último achado em aberto da auditoria registrada no PR #31
("usuários do GA4 ainda somados como se fossem aditivos"). Abro a Issue de
Correção referenciando este PR.

## O que mudou

O indicador de **Usuários** era a soma do total de cada dia. Sessão é evento e se
soma; **usuário é pessoa, e pessoa não se soma** — quem entrou segunda e voltou
quinta entrava duas vezes na conta. O efeito prático é que o número crescia com o
tamanho da janela escolhida em vez de descrever o público.

A correção é uma consulta a mais, **sem a dimensão de data**: sem ela o próprio
GA4 deduplica `totalUsers` dentro do período pedido.

A soma diária continua no código como rede de segurança — se a consulta nova não
voltar, um número inflado ainda é melhor que um zero na tela.

O indicador ganhou **dica** explicando a contagem, senão a diferença entre esse
número e a soma visível dos dias pareceria erro para quem confere.

## Como foi validado

- [x] `npm run verify` — **182 testes**, lint, tipos e contrato de arquitetura
- [x] Dois testes novos em `tests/integration/connectors.test.ts`:
      um confere 120 usuários deduplicados contra 300 se fossem somados,
      **com as sessões ainda somando 450** — sessão é aditiva e tinha que continuar sendo;
      o outro confere o retorno à soma quando a consulta sem dimensão vem vazia

## Riscos e limitações

**Uma chamada a mais por carregamento do Analytics.** A cota do GA4 é folgada
para o volume atual, mas o custo existe.

**O gráfico diário continua mostrando usuários por dia**, e a soma daquelas
barras não bate com o indicador. É correto — cada dia deduplica dentro de si —
mas é a assimetria que a dica existe para explicar.

**Não exercitado contra a API real.** O comportamento de deduplicação é o
documentado para consulta sem dimensão de data.

## Próximos passos

- Autenticação (#11): o painel segue público em `dashboard.qyra.com.br`
- Carrossel do Instagram mostrando só a primeira imagem
- Conferir os números do Clarity contra a resposta real da API

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_