### PR TITLE
feat: carrossel do Instagram mostra todas as artes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -235,6 +235,16 @@
     );
 }
 
+/* Trilho de rolagem sem a barra à vista: o carrossel de artes tem setas e
+   marcadores próprios, e a barra do sistema só sujaria a peça. A rolagem
+   continua inteira — dedo, trackpad e teclado seguem funcionando. */
+@utility qy-sem-barra {
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 /* Textura "Logo Stamp" (pág. 26): contorno do logo como carimbo de fundo. */
 @utility qy-stamp {
   background-image: url("/brand/stamp.svg");

--- a/src/components/report/creative-grid.tsx
+++ b/src/components/report/creative-grid.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { ExternalLink, ImageOff, Play } from "lucide-react";
-import { useState } from "react";
+import { ChevronLeft, ChevronRight, ExternalLink, ImageOff, Images, Play } from "lucide-react";
+import { useRef, useState } from "react";
 
 import { cn } from "@/lib/cn";
 import { formatMetric } from "@/lib/format";
@@ -51,7 +51,7 @@ function Retencao({ video }: { video: NonNullable<ContentCard["video"]> }) {
 }
 
 /**
- * A arte inteira, sem corte.
+ * Uma arte no quadro, inteira e sem corte.
  *
  * `object-cover` num quadro fixo decapitava Reels: 9:16 dentro de 5:4 perde
  * mais da metade da peça, e o que sobra costuma ser o meio do vídeo — sem
@@ -61,23 +61,166 @@ function Retencao({ video }: { video: NonNullable<ContentCard["video"]> }) {
  * para a sobra não virar barra preta. É o mesmo arquivo, então o navegador
  * baixa uma vez só.
  */
+function Quadro({ src, alt, prioridade }: { src: string; alt: string; prioridade?: boolean }) {
+  return (
+    <>
+      {/* Fundo: mesma imagem, borrada e ampliada. Preenche a sobra sem
+          inventar cor e sem competir com a peça. */}
+      {/* biome-ignore lint/performance/noImgElement: servida pelo proxy do próprio domínio */}
+      <img
+        src={src}
+        alt=""
+        aria-hidden="true"
+        loading="lazy"
+        decoding="async"
+        className="absolute inset-0 size-full scale-110 object-cover blur-xl saturate-150"
+      />
+      {/* biome-ignore lint/performance/noImgElement: servida pelo proxy do próprio domínio */}
+      <img
+        src={src}
+        alt={alt}
+        loading={prioridade ? undefined : "lazy"}
+        decoding="async"
+        className="relative size-full object-contain"
+      />
+    </>
+  );
+}
+
+function SemArte() {
+  return (
+    <div className="flex aspect-[4/5] items-center justify-center bg-surface-sunken">
+      <ImageOff className="size-6 text-ink-muted" aria-hidden="true" />
+      <span className="sr-only">Arte indisponível</span>
+    </div>
+  );
+}
+
+const SETA = cn(
+  "-translate-y-1/2 absolute top-1/2 grid size-7 place-items-center rounded-full",
+  "bg-white/90 text-plum-800 shadow-[0_2px_10px_-4px_rgba(47,37,53,0.6)]",
+  "transition-[opacity,background-color] duration-[var(--duration-fast)]",
+  "hover:bg-white disabled:pointer-events-none disabled:opacity-0",
+  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent",
+  // O círculo tem 28px para não tapar a arte, mas o dedo precisa de 44px.
+  // A área invisível cresce em volta sem mudar o desenho.
+  "after:absolute after:-inset-2 after:content-['']",
+);
+
+/**
+ * O carrossel do post, com todas as artes.
+ *
+ * A Meta entrega o álbum como uma mídia só, e por isso o cartão mostrava
+ * apenas a primeira imagem — quem monta carrossel põe o argumento nas de
+ * dentro, então o que aparecia era a capa e mais nada.
+ *
+ * A rolagem é nativa, com encaixe: dedo e trackpad já funcionavam sozinhos, e
+ * as setas existem porque no desktop com mouse não há gesto equivalente. O
+ * contador diz quantas artes existem antes de a pessoa tentar rolar — sem ele
+ * o carrossel se confunde com uma imagem parada.
+ */
+function Carrossel({ artes, titulo }: { artes: string[]; titulo: string }) {
+  const trilho = useRef<HTMLDivElement>(null);
+  const [atual, setAtual] = useState(0);
+
+  function irPara(indice: number) {
+    const elemento = trilho.current;
+    if (!elemento) return;
+    const destino = Math.min(artes.length - 1, Math.max(0, indice));
+    elemento.scrollTo({ left: destino * elemento.clientWidth, behavior: "smooth" });
+  }
+
+  function aoRolar() {
+    const elemento = trilho.current;
+    if (!elemento || elemento.clientWidth === 0) return;
+    // Arredondar em vez de dividir seco: no meio do gesto o valor é fracionário,
+    // e o marcador ficaria trocando de lugar durante a rolagem.
+    setAtual(Math.round(elemento.scrollLeft / elemento.clientWidth));
+  }
+
+  return (
+    <div className="group/carrossel relative aspect-[4/5] w-full overflow-hidden bg-plum-800">
+      <div
+        ref={trilho}
+        onScroll={aoRolar}
+        className="qy-sem-barra flex size-full snap-x snap-mandatory overflow-x-auto overscroll-x-contain"
+        // A região rola: sem foco pelo teclado, quem não usa mouse fica sem as
+        // artes de dentro mesmo com as setas ao lado.
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: região rolável precisa receber foco
+        tabIndex={0}
+        role="group"
+        aria-label={`Carrossel com ${artes.length} artes: ${titulo}`}
+      >
+        {artes.map((arte, indice) => (
+          <div key={arte} className="relative size-full shrink-0 snap-center">
+            <Quadro
+              src={arte}
+              alt={`Arte ${indice + 1} de ${artes.length}: ${titulo}`}
+              prioridade={indice === 0}
+            />
+          </div>
+        ))}
+      </div>
+
+      <span className="absolute top-2 right-2 flex items-center gap-1 rounded-full bg-plum-800/85 px-2 py-1 font-medium text-[10px] text-white tabular">
+        <Images className="size-3" aria-hidden="true" />
+        {atual + 1}/{artes.length}
+      </span>
+
+      <button
+        type="button"
+        onClick={() => irPara(atual - 1)}
+        disabled={atual === 0}
+        className={cn(SETA, "left-2")}
+        aria-label="Arte anterior"
+      >
+        <ChevronLeft className="size-4" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        onClick={() => irPara(atual + 1)}
+        disabled={atual >= artes.length - 1}
+        className={cn(SETA, "right-2")}
+        aria-label="Próxima arte"
+      >
+        <ChevronRight className="size-4" aria-hidden="true" />
+      </button>
+
+      {/* Acima de dez artes os marcadores viram uma fileira de pontinhos
+          ilegível — aí o contador sozinho informa melhor. */}
+      {artes.length <= 10 ? (
+        <div className="absolute inset-x-0 bottom-2 flex justify-center gap-1.5" aria-hidden="true">
+          {artes.map((arte, indice) => (
+            <span
+              key={arte}
+              className={cn(
+                "h-1.5 rounded-full bg-white transition-[width,opacity] duration-[var(--duration-fast)]",
+                indice === atual ? "w-4 opacity-95" : "w-1.5 opacity-50",
+              )}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** A peça do cartão: carrossel quando o post tem mais de uma arte, quadro único quando não. */
 function Arte({ criativo }: { criativo: ContentCard }) {
   const [falhou, setFalhou] = useState(false);
   const ehVideo = criativo.video !== undefined;
+  const galeria = criativo.galeria;
 
-  if (!criativo.imageUrl || falhou) {
-    return (
-      <div className="flex aspect-[4/5] items-center justify-center bg-surface-sunken">
-        <ImageOff className="size-6 text-ink-muted" aria-hidden="true" />
-        <span className="sr-only">Arte indisponível</span>
-      </div>
-    );
+  if (galeria && galeria.length > 1) {
+    // Sem `<a>` por fora: o link engoliria o gesto de arrastar e cada tentativa
+    // de rolar abriria o Instagram. O botão embaixo do cartão faz esse papel.
+    return <Carrossel artes={galeria} titulo={criativo.title} />;
   }
+
+  if (!criativo.imageUrl || falhou) return <SemArte />;
 
   const arte = (
     <div className="relative aspect-[4/5] w-full overflow-hidden bg-plum-800">
-      {/* Fundo: mesma imagem, borrada e ampliada. Preenche a sobra sem
-          inventar cor e sem competir com a peça. */}
       {/* biome-ignore lint/performance/noImgElement: servida pelo proxy do próprio domínio */}
       <img
         src={criativo.imageUrl}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -103,6 +103,15 @@ export interface ContentCard {
   linkLabel?: string;
   /** Proporção da arte, quando conhecida — evita cortar Reels em quadro largo. */
   aspectRatio?: number;
+  /**
+   * Todas as artes da peça, na ordem publicada, quando é carrossel.
+   *
+   * A Meta devolve o álbum como uma mídia só, e a `media_url` dela é a
+   * primeira imagem — mostrar apenas isso esconde o resto do carrossel, que
+   * costuma ser onde está o argumento. A primeira entrada é a mesma capa de
+   * `imageUrl`, então a lista se lê sozinha, sem precisar juntar as duas.
+   */
+  galeria?: string[];
   metrics: Array<{ label: string; value: number; format: MetricFormat }>;
   /**
    * Retenção desta peça, quando é vídeo. Retenção agregada da conta não

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -637,10 +637,10 @@ export function mockOrganico(range: DateRange, fetchedAt = NOW): ChannelReport {
     ],
     creatives: [
       ["Como funciona a terapia injetável", "Reels · 18/08/2026"],
-      ["5 mitos sobre emagrecimento que você ainda acredita", "Publicação · 15/08/2026"],
+      ["5 mitos sobre emagrecimento que você ainda acredita", "Carrossel · 15/08/2026"],
       ["Bastidores da consulta", "Reels · 12/08/2026"],
       ["Depoimento de paciente", "Publicação · 09/08/2026"],
-      ["Checklist do check-up anual", "Publicação · 06/08/2026"],
+      ["Checklist do check-up anual", "Carrossel · 06/08/2026"],
     ].map(([titulo, legenda], i) => {
       const r = Math.round(reach * [0.14, 0.11, 0.09, 0.06, 0.05][i]);
       const e = Math.round(engagement * [0.19, 0.15, 0.12, 0.05, 0.07][i]);
@@ -650,6 +650,11 @@ export function mockOrganico(range: DateRange, fetchedAt = NOW): ChannelReport {
         title: titulo,
         subtitle: legenda,
         imageUrl: arteDeDemonstracao(i + 2),
+        // Carrossel de demonstração: artes diferentes para dar para ver que a
+        // rolagem troca a peça, e não só desloca a mesma imagem.
+        galeria: (legenda as string).startsWith("Carrossel")
+          ? [0, 1, 2, 3].map((n) => arteDeDemonstracao(i + 2 + n))
+          : undefined,
         link: "https://www.instagram.com/qyra.saude/",
         linkLabel: "Ver no Instagram",
         // Reels tem vídeo; publicação estática não.

--- a/src/server/connectors/organico.ts
+++ b/src/server/connectors/organico.ts
@@ -36,11 +36,29 @@ interface MediaResponse {
     thumbnail_url?: string;
     like_count?: number;
     comments_count?: number;
+    /** Presente só em carrossel: cada imagem/vídeo do álbum, na ordem publicada. */
+    children?: { data: Array<{ id: string }> };
     insights?: { data: Array<{ name: string; values: InsightValue[] }> };
   }>;
 }
 
 const MAX_WINDOW_DAYS = 30;
+
+/** Teto de artes por carrossel — o Instagram permite 20, e é o que cabe. */
+const MAX_ARTES_DO_ALBUM = 20;
+
+/**
+ * As artes de um carrossel, cada uma pelo proxy do próprio domínio.
+ *
+ * Devolve `undefined` para publicação simples: o cartão então usa só a capa,
+ * e a galeria nem chega ao navegador. Cada filho é uma mídia como outra
+ * qualquer na Graph, então o mesmo proxy resolve — inclusive vídeo dentro do
+ * álbum, de que ele já sabe tirar o quadro de capa.
+ */
+function galeriaDoAlbum(filhos: Array<{ id: string }> | undefined): string[] | undefined {
+  if (!filhos || filhos.length < 2) return undefined;
+  return filhos.slice(0, MAX_ARTES_DO_ALBUM).map((filho) => `/publicacoes/${filho.id}/imagem`);
+}
 
 function addDays(iso: string, days: number): string {
   const d = new Date(`${iso}T00:00:00Z`);
@@ -163,7 +181,9 @@ export async function fetchOrganicoReport(range: DateRange): Promise<ChannelRepo
     "fields",
     // `media_url` é a arte do post; para vídeo ela é o arquivo, e o quadro de
     // capa vem em `thumbnail_url`. Os dois entram para o cartão ter prévia.
-    "id,caption,media_type,permalink,timestamp,like_count,comments_count,media_url,thumbnail_url,insights.metric(reach)",
+    // `children` é o que abre o carrossel: sem ele a Meta devolve o álbum como
+    // mídia única e só a primeira arte aparece.
+    "id,caption,media_type,permalink,timestamp,like_count,comments_count,media_url,thumbnail_url,children{id},insights.metric(reach)",
   );
   mediaUrl.searchParams.set("since", range.from);
   mediaUrl.searchParams.set("until", addDays(range.to, 1));
@@ -256,6 +276,7 @@ export async function fetchOrganicoReport(range: DateRange): Promise<ChannelRepo
         .filter(Boolean)
         .join(" · "),
       imageUrl: `/publicacoes/${item.id}/imagem`,
+      galeria: galeriaDoAlbum(item.children?.data),
       link: item.permalink,
       linkLabel: "Ver no Instagram",
       metrics: [

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -99,6 +99,25 @@ test("os quatro canais respondem", async ({ page }) => {
   }
 });
 
+test("o carrossel do orgânico mostra todas as artes, não só a capa", async ({ page }) => {
+  await page.goto("/organico");
+
+  const carrossel = page.getByRole("group", { name: /Carrossel com \d+ artes/ }).first();
+  await carrossel.scrollIntoViewIfNeeded();
+  await expect(carrossel).toBeVisible();
+
+  const cartao = page.locator("li", { has: carrossel }).first();
+  await expect(cartao.getByText(/^1\/\d+$/)).toBeVisible();
+
+  // Encaixe de rolagem é comportamento de navegador — vitest com jsdom não
+  // consegue provar que a arte seguinte realmente entra em quadro.
+  await cartao.getByRole("button", { name: "Próxima arte" }).click();
+  await expect(cartao.getByText(/^2\/\d+$/)).toBeVisible();
+
+  const artes = carrossel.locator("img:not([aria-hidden='true'])");
+  expect(await artes.count()).toBeGreaterThan(1);
+});
+
 test("endereço inexistente devolve a tela de não encontrado", async ({ page }) => {
   await page.goto("/rota-que-nao-existe");
   await expect(page.getByText("Página não encontrada")).toBeVisible();

--- a/tests/integration/organico-carrossel.test.ts
+++ b/tests/integration/organico-carrossel.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Carrossel do Instagram.
+ *
+ * A Meta entrega o álbum como uma mídia só, e a `media_url` dela é a primeira
+ * imagem. Sem pedir `children`, o cartão mostrava a capa e escondia o resto —
+ * que é justamente onde quem monta carrossel põe o argumento.
+ */
+
+const CREDENCIAIS = {
+  META_ACCESS_TOKEN: "token",
+  META_AD_ACCOUNT_ID: "123",
+  META_PAGE_ID: "999",
+  META_IG_USER_ID: "888",
+};
+
+interface Publicacao {
+  id: string;
+  media_type: string;
+  children?: { data: Array<{ id: string }> };
+}
+
+function grafo(publicacoes: Publicacao[]) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    if (url.includes("/media?") || url.includes("/media&") || /\/media\b/.test(url)) {
+      return new Response(
+        JSON.stringify({
+          data: publicacoes.map((p) => ({
+            ...p,
+            caption: `Post ${p.id}`,
+            timestamp: "2026-02-02T10:00:00+0000",
+            like_count: 10,
+            comments_count: 2,
+            permalink: "https://www.instagram.com/p/abc/",
+          })),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    return new Response(JSON.stringify({ data: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+}
+
+async function relatorio(publicacoes: Publicacao[]) {
+  const chamadas = grafo(publicacoes);
+  vi.stubGlobal("fetch", chamadas);
+  const { fetchOrganicoReport } = await import("@/server/connectors/organico");
+  const report = await fetchOrganicoReport({ from: "2026-02-01", to: "2026-02-03" });
+  return { report, chamadas };
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+  vi.stubEnv("QYRA_FORCE_MOCK", "false");
+  for (const [k, v] of Object.entries(CREDENCIAIS)) vi.stubEnv(k, v);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe("carrossel do orgânico", () => {
+  it("pede os filhos do álbum à Graph", async () => {
+    const { chamadas } = await relatorio([{ id: "1", media_type: "IMAGE" }]);
+
+    const urls = chamadas.mock.calls.map(([entrada]) =>
+      typeof entrada === "string" ? entrada : String(entrada),
+    );
+    // Sem `children{id}` no pedido, a resposta nunca traz as artes de dentro.
+    expect(urls.some((u) => u.includes("children"))).toBe(true);
+  });
+
+  it("monta a galeria com todas as artes, pelo proxy do próprio domínio", async () => {
+    const { report } = await relatorio([
+      {
+        id: "10",
+        media_type: "CAROUSEL_ALBUM",
+        children: { data: [{ id: "101" }, { id: "102" }, { id: "103" }] },
+      },
+    ]);
+
+    const cartao = report.creatives?.[0];
+    expect(cartao?.galeria).toEqual([
+      "/publicacoes/101/imagem",
+      "/publicacoes/102/imagem",
+      "/publicacoes/103/imagem",
+    ]);
+    // Nenhuma URL do CDN da Meta: elas expiram e a CSP do painel não abre
+    // `img-src` para host de terceiro.
+    for (const arte of cartao?.galeria ?? []) expect(arte.startsWith("/publicacoes/")).toBe(true);
+  });
+
+  it("publicação simples não carrega galeria", async () => {
+    const { report } = await relatorio([{ id: "20", media_type: "IMAGE" }]);
+
+    // `undefined` em vez de lista de um: assim a galeria nem é serializada
+    // para o navegador, e o cartão cai no quadro único.
+    expect(report.creatives?.[0]?.galeria).toBeUndefined();
+  });
+
+  it("corta o álbum no teto do Instagram", async () => {
+    const filhos = Array.from({ length: 30 }, (_, i) => ({ id: String(500 + i) }));
+    const { report } = await relatorio([
+      { id: "30", media_type: "CAROUSEL_ALBUM", children: { data: filhos } },
+    ]);
+
+    // Cada arte é uma requisição ao proxy; álbum fora do padrão não vira
+    // trinta chamadas ao carregar a tela.
+    expect(report.creatives?.[0]?.galeria).toHaveLength(20);
+  });
+});

--- a/tests/unit/creative-grid.test.tsx
+++ b/tests/unit/creative-grid.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CreativeGrid } from "@/components/report/creative-grid";
+import type { ContentCard } from "@/lib/types";
+
+/**
+ * O cartão de peça, com atenção ao carrossel.
+ *
+ * O caso que motivou o teste: álbum do Instagram aparecendo como imagem única,
+ * porque a Meta devolve o carrossel inteiro numa mídia só.
+ */
+
+const BASE: ContentCard = {
+  id: "1",
+  title: "Cinco mitos sobre emagrecimento",
+  subtitle: "Carrossel · 15/08/2026",
+  imageUrl: "/publicacoes/101/imagem",
+  link: "https://www.instagram.com/p/abc/",
+  linkLabel: "Ver no Instagram",
+  metrics: [{ label: "Alcance", value: 1200, format: "integer" }],
+};
+
+const CARROSSEL: ContentCard = {
+  ...BASE,
+  galeria: ["/publicacoes/101/imagem", "/publicacoes/102/imagem", "/publicacoes/103/imagem"],
+};
+
+/** jsdom não implementa rolagem programática, e o carrossel a usa nas setas. */
+beforeEach(() => {
+  Element.prototype.scrollTo = vi.fn();
+});
+
+describe("CreativeGrid — carrossel", () => {
+  it("renderiza todas as artes do álbum, não só a capa", () => {
+    render(<CreativeGrid criativos={[CARROSSEL]} />);
+
+    for (let i = 1; i <= 3; i++) {
+      expect(screen.getByAltText(new RegExp(`Arte ${i} de 3`))).toBeTruthy();
+    }
+  });
+
+  it("anuncia quantas artes existem antes de a pessoa tentar rolar", () => {
+    render(<CreativeGrid criativos={[CARROSSEL]} />);
+
+    // Sem contador, um carrossel parado se confunde com imagem única — foi
+    // exatamente assim que o problema passou despercebido.
+    expect(screen.getByText("1/3")).toBeTruthy();
+  });
+
+  it("dá setas para quem está no mouse, com a primeira desabilitada", async () => {
+    render(<CreativeGrid criativos={[CARROSSEL]} />);
+
+    const anterior = screen.getByRole("button", { name: /arte anterior/i }) as HTMLButtonElement;
+    const proxima = screen.getByRole("button", { name: /próxima arte/i });
+
+    expect(anterior.disabled).toBe(true);
+    await userEvent.click(proxima);
+    expect(Element.prototype.scrollTo).toHaveBeenCalled();
+  });
+
+  it("a região rolável recebe foco pelo teclado", () => {
+    render(<CreativeGrid criativos={[CARROSSEL]} />);
+
+    const regiao = screen.getByRole("group", { name: /carrossel com 3 artes/i });
+    // Só as setas não bastam: quem navega por teclado precisa alcançar a
+    // rolagem em si.
+    expect(regiao.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("não envolve o carrossel num link — arrastar abriria o post", () => {
+    render(<CreativeGrid criativos={[CARROSSEL]} />);
+
+    const links = screen.getAllByRole("link");
+    const regiao = screen.getByRole("group", { name: /carrossel/i });
+    expect(links.some((link) => link.contains(regiao))).toBe(false);
+    // O acesso ao post continua existindo, pelo botão do rodapé do cartão.
+    expect(links.some((link) => /ver no instagram/i.test(link.textContent ?? ""))).toBe(true);
+  });
+});
+
+describe("CreativeGrid — peça única", () => {
+  it("mantém a arte clicável quando não há carrossel", () => {
+    render(<CreativeGrid criativos={[BASE]} />);
+
+    expect(screen.queryByRole("group", { name: /carrossel/i })).toBeNull();
+    expect(screen.getByAltText(/Arte de Cinco mitos/)).toBeTruthy();
+    expect(screen.getAllByRole("link", { name: /ver no instagram/i }).length).toBeGreaterThan(0);
+  });
+
+  it("uma arte só não vira carrossel", () => {
+    render(<CreativeGrid criativos={[{ ...BASE, galeria: ["/publicacoes/101/imagem"] }]} />);
+
+    // Setas e contador para uma imagem só seriam ruído.
+    expect(screen.queryByRole("button", { name: /próxima arte/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — pedido direto, com print: o carrossel aparecia como imagem
única no cartão da publicação. Abro a Issue correspondente (Correção)
referenciando este PR.

## O que mudou

### A causa

A Meta entrega o álbum como **uma mídia só**, e a `media_url` dela é a primeira
imagem. O conector pedia só isso, então o cartão mostrava a capa e mais nada —
e quem monta carrossel põe o argumento nas artes de dentro. O que aparecia era
justamente a parte menos informativa da peça.

O conector agora pede `children{id}` e monta a galeria com cada arte **pelo
proxy do próprio domínio** (as URLs do CDN da Meta expiram e a CSP do painel
não abre `img-src` para host de terceiro). Teto de 20 artes, que é o que o
Instagram permite — álbum fora do padrão não vira trinta requisições ao abrir
a tela.

Vídeo dentro do álbum funciona sem nada novo: cada filho é uma mídia como
outra qualquer, e o proxy já sabe tirar o quadro de capa.

### Na tela

| Peça | Por quê |
|---|---|
| Rolagem nativa com encaixe | Dedo e trackpad já resolviam sozinhos; encaixe garante que a arte pare inteira no quadro |
| Setas | No desktop com mouse não existe gesto equivalente. Somem na ponta em vez de ficarem cinzas |
| Contador `1/4` | Diz que há mais antes de a pessoa tentar rolar — sem ele o carrossel se confunde com imagem parada, que foi exatamente como o problema passou despercebido |
| Marcadores | Posição relativa. Acima de dez artes eles viram uma fileira ilegível, e aí só o contador fica |

**O carrossel não vai dentro de um `<a>`.** Arrastar para o lado dispararia o
link e abriria o Instagram a cada tentativa de rolar. O acesso ao post continua
no botão do rodapé do cartão, que já existia.

**Acessibilidade:** a região rolável recebe foco pelo teclado — só as setas não
bastam, quem navega por teclado precisa alcançar a rolagem em si. O círculo das
setas tem 28px para não tapar a arte, mas a área de toque cresce para 44px por
fora, invisível.

## Como foi validado

- [x] `npm run verify` — **193 testes** (11 novos), lint, tipos e contrato de arquitetura
- [x] `npm run test:e2e` — **34/34**, desktop e celular
- [x] `npm run build` limpo
- [x] Captura em 1440px e 390px, com checagem programática de estouro horizontal
      da página (o trilho não vaza do cartão em nenhum dos dois)
- [x] Avanço conferido no navegador: dois cliques levam o contador de `1/4` a `3/4`

Testes novos cobrem: o pedido de `children` sair na URL da Graph; a galeria vir
toda pelo proxy; publicação simples **não** carregar galeria (`undefined`, para
nem ser serializada ao navegador); o teto de 20; e, no lado da tela, todas as
artes renderizadas, o contador, a seta inicial desabilitada, o foco por teclado
e a ausência de link envolvendo o trilho.

O encaixe de rolagem só existe em navegador de verdade, então esse ponto é
coberto no e2e, não no vitest com jsdom.

## Riscos e limitações

**Não exercitado contra a API real.** `children{id}` é o campo documentado; se a
conta não devolver o nó, o cartão volta ao comportamento de hoje — capa única,
sem quebrar.

**Uma requisição por arte visível.** Um álbum de 10 são 10 chamadas ao proxy, com
cache de 15 minutos no navegador. As artes de dentro carregam com `loading=lazy`,
mas o navegador pode começar a baixá-las antes de a pessoa rolar.

**Ordem é a que a Meta devolve.** É a ordem de publicação; não há como conferir
isso sem a resposta real.

## Próximos passos

- Autenticação (#11): o painel segue público em `dashboard.qyra.com.br`
- Conferir os números do Clarity quando houver tráfego acumulado
- Token de desenvolvedor do Google Ads ainda em acesso de teste

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_