### PR TITLE
feat: carrossel também no anúncio, e navegação sem as bolinhas coloridas

### DIFF
--- a/src/app/api/diagnostico/meta/route.ts
+++ b/src/app/api/diagnostico/meta/route.ts
@@ -29,6 +29,13 @@ interface Etapa {
   resultado: string;
 }
 
+/** A Graph trata `until` como exclusivo na borda: sem o dia a mais, o último fica de fora. */
+function addDays(iso: string, dias: number): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + dias);
+  return d.toISOString().slice(0, 10);
+}
+
 /** `act_1610215746739005` → `act_1610…9005`. */
 function mascarar(valor: string): string {
   if (valor.length <= 12) return valor;
@@ -230,6 +237,62 @@ export async function GET(request: Request) {
     });
   }
 
+  // 7. Orgânico: as publicações do período, com o carrossel aberto.
+  //    Responde a pergunta que print nenhum responde: se o álbum não aparece
+  //    porque a Meta não mandou os filhos, ou porque não houve carrossel
+  //    publicado no período.
+  if (env.META_IG_USER_ID) {
+    const desde = `since=${range.from}&until=${addDays(range.to, 1)}`;
+    etapas.push(
+      await executar(
+        "instagram-carrossel",
+        "As publicações do período trazem as artes do carrossel?",
+        `${base}/${env.META_IG_USER_ID}/media?fields=id,media_type,timestamp,children{id}&limit=50&${desde}&${auth}`,
+        (d) => {
+          const dados = d as {
+            data?: Array<{
+              media_type?: string;
+              timestamp?: string;
+              children?: { data?: Array<{ id: string }> };
+            }>;
+          };
+          const posts = dados.data ?? [];
+          if (posts.length === 0) {
+            return `Consulta aceita, mas SEM PUBLICAÇÕES entre ${range.from} e ${range.to}.`;
+          }
+
+          const albuns = posts.filter((p) => p.media_type === "CAROUSEL_ALBUM");
+          const tipos = posts.reduce<Record<string, number>>((acc, p) => {
+            const tipo = p.media_type ?? "?";
+            acc[tipo] = (acc[tipo] ?? 0) + 1;
+            return acc;
+          }, {});
+          const resumoDeTipos = Object.entries(tipos)
+            .map(([tipo, quantos]) => `${quantos} ${tipo}`)
+            .join(", ");
+
+          if (albuns.length === 0) {
+            return `${posts.length} publicação(ões) no período (${resumoDeTipos}). NENHUM CARROSSEL — não há álbum para o painel abrir.`;
+          }
+
+          const semFilhos = albuns.filter((p) => !p.children?.data?.length).length;
+          const contagens = albuns
+            .map((p) => p.children?.data?.length ?? 0)
+            .filter((n) => n > 0)
+            .join(", ");
+
+          if (semFilhos === albuns.length) {
+            return `${albuns.length} carrossel(éis) de ${posts.length} publicação(ões) (${resumoDeTipos}), mas a Meta NÃO devolveu os filhos de nenhum — provável falta de permissão instagram_basic no token.`;
+          }
+
+          return `${albuns.length} carrossel(éis) de ${posts.length} publicação(ões) (${resumoDeTipos}). Artes por álbum: ${contagens}.${
+            semFilhos > 0 ? ` ${semFilhos} álbum(ns) veio(vieram) sem filhos.` : ""
+          }`;
+        },
+      ),
+    );
+  }
+
   const primeiraFalha = etapas.find((e) => !e.ok);
 
   return NextResponse.json(
@@ -239,6 +302,9 @@ export async function GET(request: Request) {
         : "Todas as etapas passaram. Se o painel ainda aparece vazio, o problema está na montagem do relatório, não na integração.",
       periodoTestado: range,
       configuracao: {
+        // Sem isto não dá para separar "a correção não funcionou" de "a
+        // correção ainda não subiu".
+        commit: process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? null,
         versaoApi: versao,
         conta: mascarar(conta),
         contaTinhaPrefixo: contaBruta.startsWith("act_"),

--- a/src/app/criativos/[id]/imagem/route.ts
+++ b/src/app/criativos/[id]/imagem/route.ts
@@ -23,11 +23,29 @@ const ID_VALIDO = /^\d{1,25}$/;
 const HOSTS_PERMITIDOS = /(^|\.)(fbcdn\.net|facebook\.com)$/;
 
 interface RespostaDoCriativo {
-  creative?: { thumbnail_url?: string; image_url?: string };
+  creative?: {
+    thumbnail_url?: string;
+    image_url?: string;
+    /** Anúncio carrossel: uma arte por cartão, na ordem em que rodam. */
+    object_story_spec?: { link_data?: { child_attachments?: Array<{ picture?: string }> } };
+  };
 }
 
-export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
+/** Teto do carrossel na Meta. Serve de sanidade para o índice vindo da query. */
+const MAX_CARTOES = 10;
+
+/** `?cartao=2` → 2. Ausente, fora de faixa ou lixo → `null`, e serve a arte única. */
+function cartaoPedido(request: Request): number | null {
+  const bruto = new URL(request.url).searchParams.get("cartao");
+  if (bruto === null) return null;
+  const indice = Number(bruto);
+  if (!Number.isInteger(indice) || indice < 0 || indice >= MAX_CARTOES) return null;
+  return indice;
+}
+
+export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
   const { id } = await context.params;
+  const cartao = cartaoPedido(request);
 
   if (!ID_VALIDO.test(id)) {
     return NextResponse.json({ erro: "Identificador inválido." }, { status: 400 });
@@ -41,14 +59,21 @@ export async function GET(_request: Request, context: { params: Promise<{ id: st
   try {
     const anuncio = await httpJson<RespostaDoCriativo>(
       `https://graph.facebook.com/${env.META_API_VERSION}/${id}` +
-        "?fields=creative.thumbnail_width(600).thumbnail_height(600){thumbnail_url,image_url}",
+        "?fields=creative.thumbnail_width(600).thumbnail_height(600)" +
+        "{thumbnail_url,image_url,object_story_spec{link_data{child_attachments{picture}}}}",
       { headers: metaAuthHeaders(env.META_ACCESS_TOKEN as string) },
     );
 
     // `image_url` é a arte em tamanho cheio; `thumbnail_url` existe também para
     // vídeo, onde a Meta gera o quadro de capa. Preferir a primeira, cair na
     // segunda.
-    const origem = anuncio.creative?.image_url ?? anuncio.creative?.thumbnail_url;
+    const arteUnica = anuncio.creative?.image_url ?? anuncio.creative?.thumbnail_url;
+    const cartoes = anuncio.creative?.object_story_spec?.link_data?.child_attachments ?? [];
+
+    // Pedido de cartão que não existe cai na arte do anúncio em vez de 404:
+    // um álbum que encolheu entre o relatório e o clique não deve deixar
+    // buraco no carrossel.
+    const origem = (cartao === null ? undefined : cartoes[cartao]?.picture) ?? arteUnica;
     if (!origem) {
       return NextResponse.json({ erro: "Anúncio sem arte." }, { status: 404 });
     }

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { LayoutGrid, MousePointerClick } from "lucide-react";
+import {
+  ChartLine,
+  Heart,
+  LayoutGrid,
+  type LucideIcon,
+  Megaphone,
+  MousePointerClick,
+  Search,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 
@@ -9,19 +17,35 @@ import { CHANNELS } from "@/lib/channels";
 import { cn } from "@/lib/cn";
 
 /**
+ * O que cada canal é, em ícone.
+ *
+ * Antes o canal vinha como bolinha na cor do slot que ele ocupa nos gráficos.
+ * Ligava as duas coisas, mas ao preço de quatro cores fortes empilhadas fora
+ * da paleta da marca, num painel que já é roxo — e a bolinha não dizia nada
+ * sobre o canal, só repetia uma legenda.
+ *
+ * O ícone diz. A cor continua identificando a série onde ela tem função: no
+ * gráfico, ao lado do número.
+ */
+const ICONE: Record<string, LucideIcon> = {
+  "meta-ads": Megaphone,
+  "google-ads": Search,
+  ga4: ChartLine,
+  organico: Heart,
+};
+
+/**
  * Navegação principal.
  *
  * O slab escuro de cantos arredondados vem do cabeçalho do manual; aqui ele
- * vira a âncora vertical da tela. O ponto colorido ao lado de cada canal usa o
- * mesmo slot que o canal ocupa nos gráficos — a cor é a mesma em toda a
- * aplicação.
+ * vira a âncora vertical da tela.
  */
 const NAV = [
-  { href: "/", label: "Visão geral", icon: LayoutGrid, slot: null },
-  ...CHANNELS.map((c) => ({ href: c.href, label: c.label, icon: null, slot: c.slot })),
+  { href: "/", label: "Visão geral", icon: LayoutGrid },
+  ...CHANNELS.map((c) => ({ href: c.href, label: c.label, icon: ICONE[c.id] })),
   // Fora de CHANNELS de propósito: não é canal de aquisição e não produz
   // relatório de período — é o que acontece depois que a pessoa chega.
-  { href: "/comportamento", label: "Comportamento", icon: MousePointerClick, slot: null },
+  { href: "/comportamento", label: "Comportamento", icon: MousePointerClick },
 ];
 
 export function Sidebar({ className }: { className?: string }) {
@@ -48,15 +72,7 @@ export function Sidebar({ className }: { className?: string }) {
                 : "text-plum-200 hover:bg-white/8 hover:text-white",
             )}
           >
-            {Icon ? (
-              <Icon className="size-4 shrink-0" aria-hidden="true" />
-            ) : (
-              <span
-                aria-hidden="true"
-                className="size-2.5 shrink-0 rounded-full"
-                style={{ backgroundColor: `var(--color-series-${item.slot})` }}
-              />
-            )}
+            <Icon className="size-4 shrink-0" aria-hidden="true" />
             <span className="truncate">{item.label}</span>
           </Link>
         );

--- a/src/components/report/creative-grid.tsx
+++ b/src/components/report/creative-grid.tsx
@@ -62,6 +62,12 @@ function Retencao({ video }: { video: NonNullable<ContentCard["video"]> }) {
  * baixa uma vez só.
  */
 function Quadro({ src, alt, prioridade }: { src: string; alt: string; prioridade?: boolean }) {
+  const [falhou, setFalhou] = useState(false);
+
+  // Uma arte que não carrega deixaria o slide em branco, e no carrossel isso
+  // se lê como "acabou" — pior que dizer que faltou.
+  if (falhou) return <SemArte dentroDoQuadro />;
+
   return (
     <>
       {/* Fundo: mesma imagem, borrada e ampliada. Preenche a sobra sem
@@ -81,15 +87,22 @@ function Quadro({ src, alt, prioridade }: { src: string; alt: string; prioridade
         alt={alt}
         loading={prioridade ? undefined : "lazy"}
         decoding="async"
+        onError={() => setFalhou(true)}
         className="relative size-full object-contain"
       />
     </>
   );
 }
 
-function SemArte() {
+/** `dentroDoQuadro`: já existe um quadro em volta (slide do carrossel), então não repete a proporção. */
+function SemArte({ dentroDoQuadro }: { dentroDoQuadro?: boolean }) {
   return (
-    <div className="flex aspect-[4/5] items-center justify-center bg-surface-sunken">
+    <div
+      className={cn(
+        "flex items-center justify-center bg-surface-sunken",
+        dentroDoQuadro ? "size-full" : "aspect-[4/5]",
+      )}
+    >
       <ImageOff className="size-6 text-ink-muted" aria-hidden="true" />
       <span className="sr-only">Arte indisponível</span>
     </div>

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -202,6 +202,10 @@ export function mockMetaAds(range: DateRange, fetchedAt = NOW): ChannelReport {
           name: nome as string,
           campaign: campanha as string,
           imageUrl: arteDeDemonstracao(i),
+          // Anúncio carrossel: a Meta devolve um cartão por `child_attachments`.
+          galeria: (nome as string).toLowerCase().includes("carrossel")
+            ? [0, 1, 2].map((n) => arteDeDemonstracao(i + n))
+            : undefined,
           link: "https://www.instagram.com/qyra.saude/",
           linkLabel: "Ver no Instagram",
           spend: Math.round(s * 100) / 100,
@@ -226,6 +230,11 @@ export function mockMetaAds(range: DateRange, fetchedAt = NOW): ChannelReport {
       title: c.name,
       subtitle: c.campaign,
       imageUrl: c.imageUrl,
+      galeria: c.galeria,
+      // Faltava no mock: sem o link, o cartão de demonstração perdia o botão
+      // de abrir a peça — e o carrossel, que não é clicável, ficava sem saída.
+      link: c.link,
+      linkLabel: c.linkLabel,
       metrics: [
         { label: "Investimento", value: c.spend, format: "currency" as const },
         { label: "Leads", value: c.leads, format: "integer" as const },

--- a/src/server/connectors/meta-ads.ts
+++ b/src/server/connectors/meta-ads.ts
@@ -145,14 +145,18 @@ interface AdsEdgeResponse {
       instagram_permalink_url?: string;
       /** `{page_id}_{post_id}` — vira a URL pública do post no Facebook. */
       effective_object_story_id?: string;
+      /** Anúncio carrossel: um cartão por `child_attachments`, na ordem em que rodam. */
+      object_story_spec?: { link_data?: { child_attachments?: Array<{ picture?: string }> } };
     };
   }>;
 }
 
-/** Link visível para quem abre o relatório, com o rótulo certo. */
-interface LinkDaPeca {
-  url: string;
-  label: string;
+/** O que a borda `/ads` acrescenta ao cartão: para onde ele abre e quantas artes tem. */
+interface PecaDoAnuncio {
+  url?: string;
+  label?: string;
+  /** Quantidade de cartões do carrossel. 0 quando o anúncio é de arte única. */
+  cartoes: number;
 }
 
 /**
@@ -181,12 +185,18 @@ function urlDoPostNoFacebook(storyId: string | undefined): string | null {
  * uma tela de login. Botão que não leva a lugar nenhum é pior que botão
  * nenhum — um anúncio sem peça pública simplesmente não ganha botão.
  */
-async function buscarLinksDeAnuncio(): Promise<Map<string, LinkDaPeca>> {
+async function buscarLinksDeAnuncio(): Promise<Map<string, PecaDoAnuncio>> {
   const env = getEnv();
   const url = new URL(
     `https://graph.facebook.com/${env.META_API_VERSION}/act_${(env.META_AD_ACCOUNT_ID as string).replace(/^act_/, "")}/ads`,
   );
-  url.searchParams.set("fields", "id,creative{instagram_permalink_url,effective_object_story_id}");
+  url.searchParams.set(
+    "fields",
+    // `child_attachments` é o que abre o anúncio carrossel: sem ele a Meta
+    // devolve uma arte só, e o cartão mostra a capa como se fosse a peça toda.
+    "id,creative{instagram_permalink_url,effective_object_story_id," +
+      "object_story_spec{link_data{child_attachments{picture}}}}",
+  );
   url.searchParams.set("limit", "200");
 
   try {
@@ -194,15 +204,25 @@ async function buscarLinksDeAnuncio(): Promise<Map<string, LinkDaPeca>> {
       headers: metaAuthHeaders(env.META_ACCESS_TOKEN as string),
     });
 
-    const mapa = new Map<string, LinkDaPeca>();
+    const mapa = new Map<string, PecaDoAnuncio>();
     for (const anuncio of resposta.data ?? []) {
+      const filhos = anuncio.creative?.object_story_spec?.link_data?.child_attachments ?? [];
+      // Só conta como carrossel o que tem arte em todos os cartões — cartão
+      // sem `picture` viraria um slide vazio no meio do álbum.
+      const cartoes = filhos.every((filho) => filho.picture) ? filhos.length : 0;
+
       const instagram = anuncio.creative?.instagram_permalink_url;
       if (instagram) {
-        mapa.set(anuncio.id, { url: instagram, label: "Ver no Instagram" });
+        mapa.set(anuncio.id, { url: instagram, label: "Ver no Instagram", cartoes });
         continue;
       }
       const facebook = urlDoPostNoFacebook(anuncio.creative?.effective_object_story_id);
-      if (facebook) mapa.set(anuncio.id, { url: facebook, label: "Ver publicação" });
+      if (facebook) {
+        mapa.set(anuncio.id, { url: facebook, label: "Ver publicação", cartoes });
+        continue;
+      }
+      // Sem link público, mas com carrossel: o cartão ainda ganha as artes.
+      if (cartoes > 1) mapa.set(anuncio.id, { cartoes });
     }
     return mapa;
   } catch {
@@ -210,10 +230,21 @@ async function buscarLinksDeAnuncio(): Promise<Map<string, LinkDaPeca>> {
   }
 }
 
+/**
+ * As artes de um anúncio carrossel, cada uma pelo proxy do próprio domínio.
+ *
+ * `undefined` para arte única: assim a galeria nem é serializada para o
+ * navegador, e o cartão cai no quadro simples.
+ */
+function galeriaDoAnuncio(id: string, cartoes: number): string[] | undefined {
+  if (!id || cartoes < 2) return undefined;
+  return Array.from({ length: cartoes }, (_, n) => `/criativos/${id}/imagem?cartao=${n}`);
+}
+
 /** Monta os cartões de anúncio. A ordem vem de `ordenarCriativos`. */
 function montarCriativos(
   porAnuncio: MetaInsightsRow[],
-  links: Map<string, LinkDaPeca>,
+  links: Map<string, PecaDoAnuncio>,
 ): ContentCard[] {
   const cartoes = porAnuncio.map((row) => {
     const spend = num(row.spend);
@@ -254,6 +285,7 @@ function montarCriativos(
       title: c.name,
       subtitle: c.campaign,
       imageUrl: c.id ? `/criativos/${c.id}/imagem` : undefined,
+      galeria: galeriaDoAnuncio(c.id, links.get(c.id)?.cartoes ?? 0),
       link: links.get(c.id)?.url,
       linkLabel: links.get(c.id)?.label,
       metrics: [

--- a/tests/integration/meta-link-peca.test.ts
+++ b/tests/integration/meta-link-peca.test.ts
@@ -136,3 +136,97 @@ describe("link da peça no Meta Ads", () => {
     expect((await cartoes()).find((c) => c.id === "ad-face")?.link).toBeUndefined();
   });
 });
+
+describe("carrossel do anúncio", () => {
+  it("abre as artes do carrossel em galeria, uma por cartão", async () => {
+    vi.stubGlobal(
+      "fetch",
+      graph({
+        "ad-insta": {
+          instagram_permalink_url: "https://www.instagram.com/p/ABC/",
+          object_story_spec: {
+            link_data: {
+              child_attachments: [
+                { picture: "https://scontent.fbcdn.net/1.png" },
+                { picture: "https://scontent.fbcdn.net/2.png" },
+                { picture: "https://scontent.fbcdn.net/3.png" },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    const card = (await cartoes()).find((c) => c.id === "ad-insta");
+    // Cada cartão sai pelo proxy do próprio domínio, indexado: a URL do CDN da
+    // Meta expira e a CSP não abre `img-src` para host de terceiro.
+    expect(card?.galeria).toEqual([
+      "/criativos/ad-insta/imagem?cartao=0",
+      "/criativos/ad-insta/imagem?cartao=1",
+      "/criativos/ad-insta/imagem?cartao=2",
+    ]);
+    // O botão de abrir a peça continua de pé.
+    expect(card?.link).toBe("https://www.instagram.com/p/ABC/");
+  });
+
+  it("anúncio de arte única não carrega galeria", async () => {
+    vi.stubGlobal(
+      "fetch",
+      graph({ "ad-insta": { instagram_permalink_url: "https://www.instagram.com/p/ABC/" } }),
+    );
+
+    // `undefined` em vez de lista de um: a galeria nem chega ao navegador.
+    expect((await cartoes()).find((c) => c.id === "ad-insta")?.galeria).toBeUndefined();
+  });
+
+  it("cartão sem arte invalida o carrossel inteiro", async () => {
+    vi.stubGlobal(
+      "fetch",
+      graph({
+        "ad-insta": {
+          object_story_spec: {
+            link_data: {
+              child_attachments: [{ picture: "https://scontent.fbcdn.net/1.png" }, {}],
+            },
+          },
+        },
+      }),
+    );
+
+    // Um cartão sem `picture` viraria slide vazio no meio do álbum — melhor
+    // cair na arte única do anúncio.
+    expect((await cartoes()).find((c) => c.id === "ad-insta")?.galeria).toBeUndefined();
+  });
+
+  it("carrossel sem link público ainda ganha as artes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      graph({
+        "ad-sem-peca": {
+          object_story_spec: {
+            link_data: {
+              child_attachments: [
+                { picture: "https://scontent.fbcdn.net/1.png" },
+                { picture: "https://scontent.fbcdn.net/2.png" },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    const card = (await cartoes()).find((c) => c.id === "ad-sem-peca");
+    expect(card?.galeria).toHaveLength(2);
+    expect(card?.link).toBeUndefined();
+  });
+
+  it("pede child_attachments à borda /ads", async () => {
+    const espiao = graph({});
+    vi.stubGlobal("fetch", espiao);
+    await cartoes();
+
+    const urls = espiao.mock.calls.map(([e]) => (typeof e === "string" ? e : String(e)));
+    // Sem o campo no pedido, a Meta devolve uma arte só e o carrossel some.
+    expect(urls.some((u) => u.includes("child_attachments"))).toBe(true);
+  });
+});

--- a/tests/integration/proxy-criativo.test.ts
+++ b/tests/integration/proxy-criativo.test.ts
@@ -7,11 +7,45 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * identificador vindo da URL. Sem as travas, vira proxy aberto.
  */
 
-async function chamar(id: string) {
+async function chamar(id: string, busca = "") {
   const { GET } = await import("@/app/criativos/[id]/imagem/route");
-  return GET(new Request(`http://local/criativos/${id}/imagem`), {
+  return GET(new Request(`http://local/criativos/${id}/imagem${busca}`), {
     params: Promise.resolve({ id }),
   });
+}
+
+/** Anúncio carrossel com três cartões, mais a arte de capa do anúncio. */
+function anuncioCarrossel() {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("graph.facebook.com")) {
+      return new Response(
+        JSON.stringify({
+          creative: {
+            image_url: "https://scontent.fbcdn.net/capa.png",
+            object_story_spec: {
+              link_data: {
+                child_attachments: [
+                  { picture: "https://scontent.fbcdn.net/c0.png" },
+                  { picture: "https://scontent.fbcdn.net/c1.png" },
+                  { picture: "https://scontent.fbcdn.net/c2.png" },
+                ],
+              },
+            },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response("bytes", { status: 200, headers: { "content-type": "image/jpeg" } });
+  });
+}
+
+/** Qual arte do CDN a rota foi buscar. */
+function arteBuscada(espiao: ReturnType<typeof anuncioCarrossel>): string | undefined {
+  return espiao.mock.calls
+    .map(([e]) => (typeof e === "string" ? e : String(e)))
+    .find((u) => !u.includes("graph.facebook.com"));
 }
 
 beforeEach(() => {
@@ -120,5 +154,42 @@ describe("proxy da arte do criativo", () => {
     );
 
     expect((await chamar("123456")).status).toBe(404);
+  });
+});
+
+describe("cartão do carrossel", () => {
+  it("serve o cartão pedido, não a capa", async () => {
+    const espiao = anuncioCarrossel();
+    vi.stubGlobal("fetch", espiao);
+
+    expect((await chamar("123456", "?cartao=1")).status).toBe(200);
+    expect(arteBuscada(espiao)).toBe("https://scontent.fbcdn.net/c1.png");
+  });
+
+  it("sem `cartao`, continua servindo a arte do anúncio", async () => {
+    const espiao = anuncioCarrossel();
+    vi.stubGlobal("fetch", espiao);
+
+    await chamar("123456");
+    expect(arteBuscada(espiao)).toBe("https://scontent.fbcdn.net/capa.png");
+  });
+
+  it("cartão inexistente cai na arte do anúncio em vez de 404", async () => {
+    const espiao = anuncioCarrossel();
+    vi.stubGlobal("fetch", espiao);
+
+    // Álbum que encolheu entre o relatório e o clique não deve deixar buraco.
+    expect((await chamar("123456", "?cartao=7")).status).toBe(200);
+    expect(arteBuscada(espiao)).toBe("https://scontent.fbcdn.net/capa.png");
+  });
+
+  it("índice fora de faixa ou lixo na query não vira consulta estranha", async () => {
+    for (const busca of ["?cartao=-1", "?cartao=99", "?cartao=abc", "?cartao=1.5"]) {
+      const espiao = anuncioCarrossel();
+      vi.stubGlobal("fetch", espiao);
+
+      expect((await chamar("123456", busca)).status).toBe(200);
+      expect(arteBuscada(espiao)).toBe("https://scontent.fbcdn.net/capa.png");
+    }
   });
 });

--- a/tests/unit/creative-grid.test.tsx
+++ b/tests/unit/creative-grid.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -77,6 +77,20 @@ describe("CreativeGrid — carrossel", () => {
     expect(links.some((link) => link.contains(regiao))).toBe(false);
     // O acesso ao post continua existindo, pelo botão do rodapé do cartão.
     expect(links.some((link) => /ver no instagram/i.test(link.textContent ?? ""))).toBe(true);
+  });
+
+  it("arte que não carrega vira aviso, não slide em branco", () => {
+    render(<CreativeGrid criativos={[CARROSSEL]} />);
+
+    const segunda = screen.getByAltText(/Arte 2 de 3/);
+    fireEvent.error(segunda);
+
+    // Slide vazio no meio do carrossel se lê como "acabou" — pior que dizer
+    // que faltou.
+    expect(screen.getAllByText("Arte indisponível").length).toBe(1);
+    // As outras continuam de pé: uma arte quebrada não derruba o álbum.
+    expect(screen.getByAltText(/Arte 1 de 3/)).toBeTruthy();
+    expect(screen.getByAltText(/Arte 3 de 3/)).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — dois pedidos diretos: "o carrossel continuou sem aparecer"
(com print da tela de Meta Ads) e "tira aqueles pontos coloridos, tem muita cor
fora da paleta". Abro as Issues correspondentes referenciando este PR.

## O carrossel do anúncio

O PR #33 resolveu **publicação orgânica do Instagram**. O print mostrava outra
tela: **Meta Ads**, com um anúncio chamado `Topo | carrossel | v1` aparecendo
como imagem única.

São dois caminhos diferentes na API. No orgânico, o álbum vem em `children`. No
anúncio, as artes vêm em **`object_story_spec.link_data.child_attachments`** —
campo que o conector não pedia, então a Meta devolvia uma peça só.

| Peça | Mudança |
|---|---|
| Conector | pede `child_attachments{picture}` na borda `/ads`, junto com o link da peça que já buscava ali — sem requisição nova |
| Proxy de arte | aceita `?cartao=N` e serve a arte daquela posição |
| Tela | nenhuma — o `Carrossel` do PR #33 já servia, só faltava alguém preencher a galeria |

**Duas decisões de borda:**

- **Índice fora de faixa cai na arte do anúncio, não em 404.** Um álbum que
  encolheu entre o relatório e o clique não deve deixar buraco no meio do
  carrossel.
- **Cartão sem `picture` invalida o carrossel inteiro.** Um slide vazio no meio
  do álbum é pior que mostrar só a capa.

O índice da query é validado antes de tocar em qualquer coisa: inteiro, não
negativo, abaixo do teto de 10 da Meta. Lixo vira arte única em vez de consulta
estranha.

## As bolinhas da navegação

Cada canal trazia uma bolinha na cor do slot que ele ocupa nos gráficos. Ligava
as duas coisas, mas ao preço de **quatro cores fortes empilhadas** num painel
que já é roxo — e a bolinha não dizia nada sobre o canal, só repetia uma
legenda que o gráfico já dá.

Agora cada entrada tem ícone, no mesmo tratamento de "Visão geral" e
"Comportamento": megafone em Meta Ads, lupa em Google Ads, linha em Analytics,
coração em Orgânico. Uma cor de tinta só.

**O que se perde:** o vínculo visual imediato entre a entrada do menu e a cor da
série no gráfico. A cor continua identificando a série onde ela tem função — no
gráfico, ao lado do número, com legenda textual — que é onde a convenção de
visualização do projeto exige que ela esteja.

## Junto, três correções menores

**Arte que não carrega no meio do carrossel** deixava o slide em branco, e isso
se lê como "acabou". Agora vira aviso no quadro, e as outras artes seguem de pé.

**O diagnóstico da Meta ganhou etapa de carrossel**: diz quantas publicações
houve no período, quantas eram álbum e se a Meta devolveu os filhos. Responde
sem print se o problema é "não tem carrossel no período", "a Meta não mandou os
filhos" ou "a correção não subiu" — e passa a informar o commit em produção,
justamente para separar o último caso dos outros dois.

**O cartão de anúncio no modo de demonstração** perdeu o botão de abrir a peça
quando o carrossel deixou de ser clicável: o mock nunca repassava `link`. Só
afeta a demonstração, mas o modo mock existe para representar o real.

## Como foi validado

- [x] `npm run verify` — **203 testes** (10 novos), lint, tipos e contrato de arquitetura
- [x] `npm run test:e2e` — **34/34**, desktop e celular
- [x] `npm run build` limpo
- [x] Conferido no navegador em `/meta-ads`: o anúncio carrossel abre com contador `2/3` e troca de arte
- [x] Captura da navegação com os seis ícones

Testes novos cobrem: `child_attachments` sair no pedido; a galeria indexada por
cartão; anúncio de arte única não carregar galeria; cartão sem arte invalidar o
álbum; carrossel sem link público ainda ganhar as artes; e no proxy — servir o
cartão pedido, cair na capa sem `cartao`, cair na capa em índice inexistente, e
não vacilar com `-1`, `99`, `abc` ou `1.5`.

## Riscos e limitações

**Não exercitado contra a API real.** `child_attachments` é o campo documentado
para carrossel de `link_data`. Anúncio de criativo dinâmico usa `asset_feed_spec`,
que tem outra forma e **não** é coberto aqui — esses continuam mostrando a capa.

**Uma requisição por cartão visível**, com cache de 15 minutos no navegador.

**A navegação perdeu o vínculo de cor com o gráfico**, como descrito acima. Se
incomodar mais que as bolinhas incomodavam, dá para voltar a cor só na entrada
ativa.

## Próximos passos

- Autenticação (#11): o painel segue público em `dashboard.qyra.com.br`
- Criativo dinâmico (`asset_feed_spec`), se aparecer na conta
- Conferir os números do Clarity quando houver tráfego acumulado

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_