### PR TITLE
fix: tira o selo de demonstração de cima do dado real

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,19 @@ import { getOverviewReport } from "@/server/reports";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Quais canais estão em período fixo, para o selo do consolidado.
+ *
+ * `undefined` quando não há nenhum — aí o selo nem aparece.
+ */
+function rotuloDePeriodoFixo(
+  byChannel: Array<{ label: string; source: string }>,
+): string | undefined {
+  const congelados = byChannel.filter((c) => c.source === "snapshot").map((c) => c.label);
+  if (congelados.length === 0) return undefined;
+  return `${congelados.join(" e ")} em período fixo`;
+}
+
 export default async function OverviewPage({
   searchParams,
 }: {
@@ -32,6 +45,10 @@ export default async function OverviewPage({
         title="Visão geral"
         description="Investimento, resultado e audiência somados de Meta Ads, Google Ads, Analytics e orgânico."
         source={report.source}
+        // "Período fixo" sozinho, aqui, sugeriria que a tela toda está
+        // congelada. Nomear o canal é o que separa "parte disto é de outro
+        // período" de "nada disto é atual".
+        sourceLabel={rotuloDePeriodoFixo(report.byChannel)}
         actions={<DateRangePicker range={range} preset={preset} />}
       />
 

--- a/src/components/layout/page-header.tsx
+++ b/src/components/layout/page-header.tsx
@@ -14,6 +14,7 @@ export function PageHeader({
   description,
   source,
   periodLabel,
+  sourceLabel,
   actions,
   className,
 }: {
@@ -22,6 +23,11 @@ export function PageHeader({
   source?: DataSource;
   /** Período real dos dados, quando não acompanha o filtro. */
   periodLabel?: string;
+  /**
+   * Texto do selo de período fixo, quando "Período fixo" sozinho enganaria.
+   * No consolidado é o caso: só parte dos canais está congelada.
+   */
+  sourceLabel?: string;
   actions?: React.ReactNode;
   className?: string;
 }) {
@@ -41,7 +47,7 @@ export function PageHeader({
               e o período precisa estar visível para ninguém ler como atual. */}
           {source === "snapshot" ? (
             <Badge tone="accent" title="Dados reais exportados da plataforma, em período fixo">
-              {periodLabel ? `Período fixo · ${periodLabel}` : "Período fixo"}
+              {sourceLabel ?? (periodLabel ? `Período fixo · ${periodLabel}` : "Período fixo")}
             </Badge>
           ) : null}
         </div>

--- a/src/server/reports.ts
+++ b/src/server/reports.ts
@@ -7,6 +7,7 @@ import type {
   ChannelId,
   ChannelReport,
   ClarityResumo,
+  DataSource,
   DateRange,
   Kpi,
   Notice,
@@ -129,6 +130,27 @@ export async function getAllReports(range: DateRange): Promise<ChannelResult[]> 
 }
 
 /** Soma a primeira métrica existente entre as candidatas. */
+/**
+ * De onde vem o consolidado, dadas as origens de cada canal.
+ *
+ * As três origens não têm o mesmo peso. `mock` é número inventado, e somar isso
+ * a dado real produz um total que não existe — basta um canal assim para a tela
+ * inteira precisar avisar. `snapshot` é dado REAL da conta, só que congelado no
+ * período do export: some com honestidade num total, desde que o rótulo diga
+ * que parte do período é fixa.
+ *
+ * A regra anterior era "todo canal ao vivo, senão demonstração", e tratava
+ * snapshot como se fosse invenção. Resultado: com o Google Ads congelado, a
+ * visão geral carimbava "Dados de demonstração" sobre investimento, sessões e
+ * conversões reais — o pior erro que um painel pode cometer, que é desacreditar
+ * o próprio número certo.
+ */
+export function origemDoConsolidado(origens: DataSource[]): DataSource {
+  if (origens.length === 0) return "mock";
+  if (origens.includes("mock")) return "mock";
+  return origens.includes("snapshot") ? "snapshot" : "live";
+}
+
 function pickTotal(report: ChannelReport, keys: string[]): number {
   for (const key of keys) {
     if (report.series.some((p) => key in p)) return total(report.series, key);
@@ -272,16 +294,11 @@ export async function getOverviewReport(range: DateRange): Promise<OverviewRepor
 
   const series = [...dateIndex.values()].sort((a, b) => a.date.localeCompare(b.date));
 
-  // Origem conservadora: basta um canal em demonstração para o consolidado
-  // deixar de ser dado real. O critério anterior — "algum canal ao vivo" —
-  // escondia o aviso justamente na configuração mais comum, a de quem acabou de
-  // conectar o primeiro canal, e somava investimento fictício ao total.
-  const todosAoVivo = byChannel.length > 0 && byChannel.every((canal) => canal.source === "live");
   const failedChannels = results.filter((r) => r.report === null).map((r) => r.channel);
 
   return {
     range,
-    source: todosAoVivo ? "live" : "mock",
+    source: origemDoConsolidado(byChannel.map((canal) => canal.source)),
     fetchedAt: new Date().toISOString(),
     kpis: [
       {

--- a/tests/integration/reports.test.ts
+++ b/tests/integration/reports.test.ts
@@ -160,8 +160,33 @@ describe("origem do dado na visão geral", () => {
     const overview = await getOverviewReport(RANGE);
 
     for (const canal of overview.byChannel) {
-      expect(["live", "mock"]).toContain(canal.source);
+      expect(["live", "mock", "snapshot"]).toContain(canal.source);
     }
+  });
+
+  /**
+   * Regressão: `snapshot` é dado REAL da conta, congelado no período do export.
+   * A regra era "todo canal ao vivo, senão demonstração", e com o Google Ads
+   * congelado a visão geral carimbava "Dados de demonstração" sobre
+   * investimento, sessões e conversões reais — desacreditando o próprio número
+   * certo, que é o pior erro que um painel pode cometer.
+   */
+  it("dado congelado é real: não vira demonstração", async () => {
+    const { origemDoConsolidado } = await import("@/server/reports");
+
+    expect(origemDoConsolidado(["live", "snapshot"])).toBe("snapshot");
+    expect(origemDoConsolidado(["snapshot"])).toBe("snapshot");
+    expect(origemDoConsolidado(["live", "live"])).toBe("live");
+  });
+
+  it("um canal fictício ainda contamina o total inteiro", async () => {
+    const { origemDoConsolidado } = await import("@/server/reports");
+
+    // Número inventado somado a número real produz um total que não existe.
+    expect(origemDoConsolidado(["live", "mock"])).toBe("mock");
+    expect(origemDoConsolidado(["snapshot", "mock"])).toBe("mock");
+    // Sem canal nenhum não há o que declarar real.
+    expect(origemDoConsolidado([])).toBe("mock");
   });
 
   it("não soma conversões do site às conversões pagas na série", async () => {


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — pedido direto, repetido: a visão geral em produção carimba
"Dados de demonstração" sobre números reais (R$ 2.196,58 de investimento, 9
conversões). Abro a Issue de Correção referenciando este PR.

## Por que isto é um PR separado

A correção já existia no PR #35, junto da autenticação — que está parada
esperando `QYRA_SENHA` ser cadastrada na Vercel. Juntar as duas coisas travou
uma correção de dez linhas atrás de uma tarefa que depende de terceiro.

Este PR carrega **só a correção do selo**, e pode ser mergeado sozinho. O #35
segue com a autenticação; quando ele entrar, o Git resolve a duplicata sem
conflito (mesmo commit).

## O que estava errado

O consolidado só se declarava real se **todo** canal fosse `live`:

```ts
const todosAoVivo = byChannel.length > 0 && byChannel.every((c) => c.source === "live");
source: todosAoVivo ? "live" : "mock"
```

O Google Ads vem de **snapshot** — dado real da conta, congelado no período do
export, enquanto o token de desenvolvedor não sai do acesso de teste. O próprio
código já dizia isso (`google-ads-snapshot.ts`: *"É dado REAL da conta,
congelado no período do export — não é demonstração"*), mas a regra do
consolidado tratava snapshot como invenção.

Conferido antes de subir: **nenhum canal cai em `mock` nesta conta.** O caminho
de mock só existe para credencial ausente ou `QYRA_FORCE_MOCK`, e o
`/api/health` confirma as quatro credenciais presentes. Google Ads, ao falhar,
cai em snapshot — nunca em mock. Ou seja, o selo estava errado **sempre**, não
só às vezes.

## A regra agora

| Origens dos canais | Consolidado |
|---|---|
| só `live` | `live` — sem selo |
| `live` + `snapshot` | `snapshot` — tudo real, parte do período é fixa |
| qualquer `mock` | `mock` — ficção somada a dado real dá um total que não existe |
| nenhum canal | `mock` |

O selo passa a nomear o canal congelado — **"Google Ads em período fixo"**. Um
"Período fixo" seco ali sugeriria que a tela inteira é de outro período,
trocando um erro por outro.

## Efeito em produção

O selo âmbar "Dados de demonstração" **some** da visão geral. No lugar entra um
selo discreto dizendo que o Google Ads é de período fixo — que é a verdade, e
que sai sozinho quando o token for aprovado.

Investimento, conversões e sessões nunca estiveram errados. Só a etiqueta.

## Como foi validado

- [x] `npm run verify` — **205 testes** (2 novos), lint, tipos e contrato de arquitetura
- [x] Testes de regressão sobre as seis combinações de origem, incluindo a que
      causou o bug (`["live", "snapshot"]` → `snapshot`, não `mock`)
- [x] O teste que cravava o comportamento antigo foi ajustado: ele aceitava só
      `live` e `mock` como origem de canal, e teria barrado `snapshot`

## Riscos e limitações

**Não muda nenhum número.** O total sempre somou dado real.

**A regra continua conservadora com `mock`:** um canal sem credencial ainda
carimba a tela toda de demonstração. É proposital — ali o total realmente
contém número inventado.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_