### PR TITLE
fix: tira o selo de origem do cabeçalho da visão geral

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,19 +15,6 @@ import { getOverviewReport } from "@/server/reports";
 
 export const dynamic = "force-dynamic";
 
-/**
- * Quais canais estão em período fixo, para o selo do consolidado.
- *
- * `undefined` quando não há nenhum — aí o selo nem aparece.
- */
-function rotuloDePeriodoFixo(
-  byChannel: Array<{ label: string; source: string }>,
-): string | undefined {
-  const congelados = byChannel.filter((c) => c.source === "snapshot").map((c) => c.label);
-  if (congelados.length === 0) return undefined;
-  return `${congelados.join(" e ")} em período fixo`;
-}
-
 export default async function OverviewPage({
   searchParams,
 }: {
@@ -44,11 +31,10 @@ export default async function OverviewPage({
       <PageHeader
         title="Visão geral"
         description="Investimento, resultado e audiência somados de Meta Ads, Google Ads, Analytics e orgânico."
-        source={report.source}
-        // "Período fixo" sozinho, aqui, sugeriria que a tela toda está
-        // congelada. Nomear o canal é o que separa "parte disto é de outro
-        // período" de "nada disto é atual".
-        sourceLabel={rotuloDePeriodoFixo(report.byChannel)}
+        // Sem selo de origem, por decisão de produto: esta tela é aberta na
+        // frente do cliente, e etiqueta ao lado do título rouba a atenção do
+        // número. A origem de cada canal continua visível onde ela é
+        // acionável — no cartão do próprio canal e no rótulo do gráfico.
         actions={<DateRangePicker range={range} preset={preset} />}
       />
 


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — pedido direto: nenhum selo ao lado do título da visão geral.
O PR #36 já tinha corrigido o selo **errado** ("Dados de demonstração" sobre
dado real); este tira o selo **inteiro** daquele cabeçalho.

## O que mudou

Uma linha: o `PageHeader` da visão geral não recebe mais `source`, então nem o
selo de demonstração nem o de período fixo aparecem ali.

A razão é de produto, não técnica: **esta é a tela aberta na frente do
cliente**, e etiqueta ao lado do título compete com o número — que é a única
coisa que a reunião precisa ler naquele momento.

## A informação não sumiu do painel

Foi para onde ela é acionável, em vez de ficar como aviso permanente:

| Onde | O que continua dizendo |
|---|---|
| Gráfico "Investimento por canal" | Rotula a barra como **"Google Ads · período fixo"** |
| Tela do Google Ads | Selo próprio, com o período real do export |
| Cada tela de canal | A própria origem, quando não está ao vivo |
| Tabela "Resumo por canal" | Na mesma página, logo abaixo |

## O que se perde

**Se um dia uma credencial cair**, a visão geral passa a somar dado de
demonstração sem avisar no topo. O risco é real e a decisão de assumi-lo é sua
— vale saber que existe.

Duas coisas reduzem o estrago: a tela do canal afetado continua carimbada, e
`/api/health` responde quais credenciais estão configuradas. Se preferir, dá
para trocar isto por um selo que aparece **só** quando há canal em
demonstração, mantendo o cabeçalho limpo na operação normal — é a mesma linha,
com uma condição.

## Como foi validado

- [x] `npm run verify` — 205 testes, lint, tipos e contrato de arquitetura
- [x] `npm run build` limpo; a função que montava o rótulo foi removida junto,
      senão o Knip acusaria código morto
- [x] Conferido no navegador **com `QYRA_FORCE_MOCK=true`** — o modo que mais
      insistia em mostrar o selo — e o cabeçalho fica só com o título

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_