### PR TITLE
feat: tela de Vendas, pelo Kommo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,13 @@ REPORT_CACHE_TTL=300
 # Teto de requisições por IP nas rotas de API.
 RATE_LIMIT_MAX=60
 RATE_LIMIT_WINDOW_MS=60000
+
+# ---- Kommo (CRM de vendas) -------------------------------------------------
+
+# O nome que aparece na URL da conta: https://SUBDOMINIO.kommo.com
+KOMMO_SUBDOMAIN=
+
+# Chave de longa duração da integração privada (Kommo > Configurações >
+# Integrações > sua integração > Chaves e escopos). Sem ela a tela de Vendas
+# roda em demonstração. Ver docs/integracoes.md.
+KOMMO_ACCESS_TOKEN=

--- a/docs/integracoes.md
+++ b/docs/integracoes.md
@@ -169,10 +169,10 @@ Kommo diz quanto daquilo virou dinheiro.
 
 ### O que cadastrar
 
-| Variável | Onde encontrar |
+| Variável | Valor |
 |---|---|
-| `KOMMO_SUBDOMAIN` | O nome na URL da conta: `https://SUBDOMINIO.kommo.com` |
-| `KOMMO_ACCESS_TOKEN` | Chave de longa duração da integração privada |
+| `KOMMO_SUBDOMAIN` | `marketingqyracombr` — o nome na URL da conta. Não é segredo |
+| `KOMMO_ACCESS_TOKEN` | Chave de longa duração da integração privada. **É segredo** |
 
 ### Passo a passo
 
@@ -214,6 +214,29 @@ português funciona. Quando nenhum negócio traz UTM, a tela avisa quem opera �
 não o cliente.
 
 O padrão de UTM dos links publicados está em [`utm.md`](./utm.md).
+
+### Duas coisas que o painel não resolve sozinho
+
+**Valor do negócio.** O funil da conta hoje mostra `R$ 0` em todas as etapas: o
+campo de valor não vem preenchido. Enquanto for assim, receita e ticket médio
+aparecem zerados — corretamente, porque não há valor registrado. A tela avisa
+quem opera, com o número de negócios ganhos sem valor, para o zero não ser lido
+como "não vendemos nada".
+
+**UTM em lead de WhatsApp e Instagram.** Boa parte dos negócios entra por DM,
+que não passa por URL com parâmetro e portanto não carrega UTM naturalmente.
+Ligar venda a campanha nesses casos exige uma automação capturando a origem da
+conversa e gravando no negócio — é o ponto em que uma ferramenta como o n8n
+tem função de verdade.
+
+### Leads de entrada
+
+A área de **leads de entrada** (não organizados) vive num endpoint separado e
+**não aparece em `/leads`**. O conector conta esses registros e os mostra como
+uma linha do funil; sem isso o topo do funil simplesmente sumiria.
+
+Só a contagem: o formato desses registros difere do de um negócio comum, e
+adivinhar a forma para extrair valor renderia um total inventado.
 
 ### Limites
 

--- a/docs/integracoes.md
+++ b/docs/integracoes.md
@@ -159,3 +159,64 @@ atalho para ver o mapa lá.
 | GA4 devolve zero em tudo | ID de medição no lugar do ID da propriedade |
 | Tabela de publicações vazia | Falta `instagram_manage_insights` |
 | Meta com `spend` mas sem leads | O tipo de ação do pixel não está em `LEAD_ACTIONS` (`src/server/connectors/meta-ads.ts`) |
+
+---
+
+## Kommo (vendas)
+
+O CRM é o que fecha o ciclo do painel: os outros canais param no lead, e o
+Kommo diz quanto daquilo virou dinheiro.
+
+### O que cadastrar
+
+| Variável | Onde encontrar |
+|---|---|
+| `KOMMO_SUBDOMAIN` | O nome na URL da conta: `https://SUBDOMINIO.kommo.com` |
+| `KOMMO_ACCESS_TOKEN` | Chave de longa duração da integração privada |
+
+### Passo a passo
+
+1. No Kommo, **Configurações → Integrações → Criar integração** (a aba fica ao
+   lado de "Instaladas"). Marque que é uma **integração privada** — ela vale só
+   para esta conta e não passa por revisão do Kommo.
+2. Preencha nome e descrição. O campo de **redirect URI** é obrigatório mesmo
+   sem usar OAuth; pode ser `https://dashboard.qyra.com.br/api/kommo/callback`.
+3. Nos **escopos**, marque leitura de negócios (leads), contatos e funis. O
+   painel **nunca escreve** no Kommo — se houver opção de somente leitura, é
+   ela que deve ficar marcada.
+4. Salve. Abra a integração e vá em **Chaves e escopos**: ali fica a **chave de
+   longa duração**. É esse valor que vai em `KOMMO_ACCESS_TOKEN`.
+5. Cadastre as duas variáveis na Vercel e faça um novo deploy.
+
+### O que o painel lê
+
+Só leitura, e só o necessário:
+
+- **negócios** (`/api/v4/leads`) criados no período, com valor, etapa e datas de
+  criação e fechamento;
+- **funis e etapas** (`/api/v4/leads/pipelines`), para o funil sair com o nome
+  das etapas em vez de números.
+
+O Kommo herdou do amoCRM dois identificadores fixos, iguais em toda conta:
+**142 é venda ganha, 143 é perdido**. As demais etapas são as que a clínica
+criou.
+
+### A UTM é o que liga venda a campanha
+
+Sem `utm_source` e `utm_campaign` gravados **no negócio**, o painel mostra
+receita e ticket médio, mas não consegue dizer **qual campanha gerou a venda** —
+que é a pergunta que justifica o painel inteiro.
+
+Isso depende de o formulário (ou a integração de WhatsApp) passar as UTMs para
+campos personalizados do negócio no Kommo. O conector procura pelos nomes
+`utm_source`, `utm_campaign` e também por `origem` e `campanha`, então campo em
+português funciona. Quando nenhum negócio traz UTM, a tela avisa quem opera —
+não o cliente.
+
+O padrão de UTM dos links publicados está em [`utm.md`](./utm.md).
+
+### Limites
+
+A API do Kommo limita a cerca de **7 requisições por segundo** e devolve no
+máximo **250 negócios por página**. O conector pagina até 20 páginas — 5.000
+negócios num período —, o que cobre com folga o volume de uma clínica.

--- a/src/app/vendas/loading.tsx
+++ b/src/app/vendas/loading.tsx
@@ -1,0 +1,5 @@
+import { ReportSkeleton } from "@/components/report/report-skeleton";
+
+export default function Loading() {
+  return <ReportSkeleton />;
+}

--- a/src/app/vendas/page.tsx
+++ b/src/app/vendas/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+import { ChannelPage, type ChannelPageProps } from "@/app/_shared/channel-page";
+
+export const metadata: Metadata = { title: "Vendas" };
+
+export default function Page({ searchParams }: ChannelPageProps) {
+  return <ChannelPage channel="vendas" searchParams={searchParams} />;
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -2,6 +2,7 @@
 
 import {
   ChartLine,
+  HandCoins,
   Heart,
   LayoutGrid,
   type LucideIcon,
@@ -13,7 +14,7 @@ import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 
 import { QyraLogo } from "@/components/brand/logo";
-import { CHANNELS } from "@/lib/channels";
+import { RELATORIOS } from "@/lib/channels";
 import { cn } from "@/lib/cn";
 
 /**
@@ -32,6 +33,7 @@ const ICONE: Record<string, LucideIcon> = {
   "google-ads": Search,
   ga4: ChartLine,
   organico: Heart,
+  vendas: HandCoins,
 };
 
 /**
@@ -42,7 +44,7 @@ const ICONE: Record<string, LucideIcon> = {
  */
 const NAV = [
   { href: "/", label: "Visão geral", icon: LayoutGrid },
-  ...CHANNELS.map((c) => ({ href: c.href, label: c.label, icon: ICONE[c.id] })),
+  ...RELATORIOS.map((c) => ({ href: c.href, label: c.label, icon: ICONE[c.id] })),
   // Fora de CHANNELS de propósito: não é canal de aquisição e não produz
   // relatório de período — é o que acontece depois que a pessoa chega.
   { href: "/comportamento", label: "Comportamento", icon: MousePointerClick },

--- a/src/lib/channels.ts
+++ b/src/lib/channels.ts
@@ -41,7 +41,25 @@ export const CHANNELS: readonly ChannelMeta[] = [
   },
 ] as const;
 
-const BY_ID = new Map(CHANNELS.map((c) => [c.id, c]));
+/**
+ * Vendas: o que acontece depois do lead.
+ *
+ * Fora de `CHANNELS` de propósito — a visão geral consolida investimento e
+ * conversão de mídia, e receita não pertence àquela soma. Mas é um relatório
+ * completo, com as mesmas peças das telas de canal.
+ */
+export const VENDAS: ChannelMeta = {
+  id: "vendas",
+  label: "Vendas",
+  href: "/vendas",
+  slot: 5,
+  description: "Negócios fechados, receita e conversão de lead em venda, pelo Kommo",
+};
+
+/** Tudo que tem tela de relatório, canal de aquisição ou não. */
+export const RELATORIOS: readonly ChannelMeta[] = [...CHANNELS, VENDAS];
+
+const BY_ID = new Map(RELATORIOS.map((c) => [c.id, c]));
 
 export function getChannel(id: ChannelId): ChannelMeta {
   const meta = BY_ID.get(id);

--- a/src/lib/channels.ts
+++ b/src/lib/channels.ts
@@ -48,7 +48,7 @@ export const CHANNELS: readonly ChannelMeta[] = [
  * conversão de mídia, e receita não pertence àquela soma. Mas é um relatório
  * completo, com as mesmas peças das telas de canal.
  */
-export const VENDAS: ChannelMeta = {
+const VENDAS: ChannelMeta = {
   id: "vendas",
   label: "Vendas",
   href: "/vendas",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,7 +6,15 @@
  * não toca em nenhum componente.
  */
 
-export const CHANNEL_IDS = ["meta-ads", "google-ads", "ga4", "organico"] as const;
+/**
+ * `vendas` está aqui, mas **fora de `CHANNELS`** (ver `lib/channels.ts`).
+ *
+ * Ela é um relatório como os outros — tem período, série e indicadores, e usa
+ * a mesma tela. Não é canal de aquisição: não tem investimento, e somar
+ * receita ao total de mídia na visão geral produziria um número sem
+ * significado.
+ */
+export const CHANNEL_IDS = ["meta-ads", "google-ads", "ga4", "organico", "vendas"] as const;
 export type ChannelId = (typeof CHANNEL_IDS)[number];
 
 /**

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -734,3 +734,143 @@ export function mockClarity(): ClarityResumo {
     projeto: "y5l8wdf890",
   };
 }
+
+/* -------------------------------------------------------------- Vendas (Kommo) */
+
+export function mockVendas(range: DateRange, fetchedAt = NOW): ChannelReport {
+  const days = eachDay(range);
+
+  const series: SeriesPoint[] = days.map((date) => {
+    const leads = Math.round(dailyValue("vendas:leads", date, 11));
+    // Nem todo dia tem venda: uma clínica fecha em blocos, e uma série que
+    // nunca toca o zero descreve um negócio que não existe.
+    const fecha = noise(`vendas:fecha:${date}`) > 0.42;
+    const vendas = fecha ? Math.max(1, Math.round(dailyValue("vendas:qtd", date, 2.4))) : 0;
+    const ticket = 1_180 + noise(`vendas:ticket:${date}`) * 900;
+    return {
+      date,
+      leads,
+      vendas,
+      receita: Math.round(vendas * ticket * 100) / 100,
+    };
+  });
+
+  const leads = sum(series, "leads");
+  const vendas = sum(series, "vendas");
+  const receita = sum(series, "receita");
+
+  return {
+    channel: "vendas",
+    label: "Vendas",
+    source: "mock",
+    range,
+    fetchedAt,
+    kpis: [
+      {
+        key: "vendas",
+        label: "Vendas ganhas",
+        value: vendas,
+        previousValue: vendas * 0.87,
+        format: "integer",
+      },
+      {
+        key: "receita",
+        label: "Receita",
+        value: receita,
+        previousValue: receita * 0.81,
+        format: "currency",
+      },
+      {
+        key: "ticket",
+        label: "Ticket médio",
+        value: safeDiv(receita, vendas),
+        previousValue: safeDiv(receita * 0.81, vendas * 0.87),
+        format: "currency",
+      },
+      {
+        key: "conversao",
+        label: "Lead vira venda",
+        value: safeDiv(vendas, leads),
+        previousValue: safeDiv(vendas * 0.87, leads * 0.94),
+        format: "percent",
+        hint: "Negócios ganhos sobre todos os negócios criados no período.",
+      },
+      {
+        key: "ciclo",
+        label: "Ciclo de fechamento",
+        value: 6.4,
+        previousValue: 7.1,
+        format: "decimal",
+        lowerIsBetter: true,
+        hint: "Dias entre a criação do negócio e o fechamento, na média dos que fecharam.",
+      },
+      { key: "emAberto", label: "Em aberto", value: Math.round(leads * 0.34), format: "integer" },
+    ],
+    series,
+    seriesDefs: [
+      { key: "receita", label: "Receita", format: "currency", slot: 5 },
+      { key: "vendas", label: "Vendas", format: "integer", slot: 2 },
+    ],
+    tables: [
+      {
+        title: "Negócios por etapa",
+        description: "Onde os negócios do período estão parados, e quanto há em cada etapa.",
+        columns: [
+          { key: "etapa", label: "Etapa", align: "left" },
+          { key: "negocios", label: "Negócios", format: "integer", align: "right" },
+          { key: "valor", label: "Valor", format: "currency", align: "right" },
+        ],
+        // As etapas saem dos mesmos totais dos indicadores. Inventar fatias
+        // soltas produzia um funil que contradizia o topo da tela — e num
+        // painel de demonstração isso lê como erro de cálculo, não como dado
+        // fictício.
+        rows: (() => {
+          const perdidos = Math.round((leads - vendas) * 0.34);
+          const abertos = leads - vendas - perdidos;
+          return [
+            ["Primeiro contato", Math.round(abertos * 0.52)],
+            ["Avaliação agendada", Math.round(abertos * 0.31)],
+            ["Proposta enviada", abertos - Math.round(abertos * 0.52) - Math.round(abertos * 0.31)],
+            ["Venda ganha", vendas],
+            ["Perdido", perdidos],
+          ].map(([etapa, negocios]) => ({
+            etapa: etapa as string,
+            negocios: negocios as number,
+            valor: Math.round((negocios as number) * 1_620 * 100) / 100,
+          }));
+        })(),
+      },
+      {
+        title: "Vendas por origem",
+        description: "De onde vieram os negócios que fecharam, pela UTM registrada no Kommo.",
+        columns: [
+          { key: "origem", label: "Origem", align: "left" },
+          { key: "leads", label: "Negócios", format: "integer", align: "right" },
+          { key: "vendas", label: "Ganhos", format: "integer", align: "right" },
+          { key: "taxa", label: "Conversão", format: "percent", align: "right" },
+          { key: "receita", label: "Receita", format: "currency", align: "right" },
+        ],
+        // Mesma disciplina do funil: as fatias somam 1, e os ganhos de cada
+        // origem somam as vendas do período.
+        rows: [
+          ["meta · Conversão | Emagrecimento", 0.42, 0.44],
+          ["google · Search | Marca", 0.18, 0.27],
+          ["instagram · Bio", 0.15, 0.08],
+          ["indicação", 0.11, 0.17],
+          ["Sem UTM", 0.14, 0.04],
+        ].map(([origem, fatiaLeads, fatiaVendas]) => {
+          const n = Math.round(leads * (fatiaLeads as number));
+          const ganhos = Math.round(vendas * (fatiaVendas as number));
+          return {
+            origem: origem as string,
+            leads: n,
+            vendas: ganhos,
+            taxa: safeDiv(ganhos, n),
+            receita: Math.round(ganhos * 1_640 * 100) / 100,
+          };
+        }),
+      },
+    ],
+    notices: [],
+  };
+}

--- a/src/server/connectors/google-ads.ts
+++ b/src/server/connectors/google-ads.ts
@@ -6,7 +6,7 @@ import type { ChannelReport, DateRange, SeriesPoint } from "@/lib/types";
 import { mockGoogleAds } from "@/mocks/reports";
 import { getCredentials, getEnv, isForceMock } from "@/server/env";
 import { getGoogleAccessToken } from "@/server/lib/google-auth";
-import { HttpError, httpJson, redactSecrets } from "@/server/lib/http";
+import { descreverFalha, HttpError, httpJson } from "@/server/lib/http";
 import { buildGoogleAdsSnapshotReport } from "./google-ads-snapshot";
 
 /**
@@ -123,17 +123,6 @@ async function runQuery(query: string): Promise<GoogleAdsRow[]> {
 function ehTokenAguardandoAprovacao(erro: unknown): boolean {
   const texto = erro instanceof Error ? erro.message + (erro as HttpError).body : "";
   return /DEVELOPER_TOKEN_NOT_APPROVED|DEVELOPER_TOKEN_PROHIBITED/i.test(texto);
-}
-
-/**
- * Resumo curto do erro para o aviso na tela. Passa pelo `redactSecrets` porque
- * a resposta da Google costuma ecoar a requisição, e a requisição leva token.
- */
-function descreverFalha(erro: unknown): string {
-  const bruto = erro instanceof Error ? erro.message : String(erro);
-  const corpo = (erro as HttpError)?.body;
-  const texto = redactSecrets(typeof corpo === "string" && corpo ? `${bruto} — ${corpo}` : bruto);
-  return texto.length > 240 ? `${texto.slice(0, 240)}…` : texto;
 }
 
 export async function fetchGoogleAdsReport(range: DateRange): Promise<ChannelReport> {

--- a/src/server/connectors/kommo.ts
+++ b/src/server/connectors/kommo.ts
@@ -1,0 +1,353 @@
+import "server-only";
+
+import { avisoOperacao } from "@/lib/avisos";
+import { eachDay } from "@/lib/date-range";
+import type { ChannelReport, DateRange, SeriesPoint, TableBlock } from "@/lib/types";
+import { mockVendas } from "@/mocks/reports";
+import { getCredentials, getEnv, isForceMock } from "@/server/env";
+import { descreverFalha, httpJson } from "@/server/lib/http";
+
+/**
+ * Vendas, pelo Kommo.
+ *
+ * É a peça que fecha o ciclo: os outros conectores param no lead, e este diz
+ * quanto daquilo virou dinheiro. Sem ele, "custo por lead" é o fim da linha e
+ * ninguém sabe se o lead barato era lead bom.
+ *
+ * O Kommo herdou do amoCRM dois identificadores de etapa fixos, iguais em toda
+ * conta: **142 é venda ganha e 143 é venda perdida**. Os demais `status_id`
+ * são as etapas que a própria clínica criou, e variam por funil — por isso os
+ * nomes vêm da API em vez de ficarem escritos aqui.
+ */
+
+const GANHO = 142;
+const PERDIDO = 143;
+
+/** Teto da API por página. Acima disso ela ignora o valor e devolve 250. */
+const POR_PAGINA = 250;
+
+/** Trava de segurança: 20 páginas são 5.000 negócios num período. */
+const MAX_PAGINAS = 20;
+
+interface LeadDoKommo {
+  id: number;
+  name?: string;
+  price?: number;
+  status_id?: number;
+  pipeline_id?: number;
+  /** Unix em segundos, não milissegundos. */
+  created_at?: number;
+  closed_at?: number;
+  responsible_user_id?: number;
+  custom_fields_values?: Array<{
+    field_name?: string;
+    field_code?: string;
+    values?: Array<{ value?: string | number | boolean }>;
+  }> | null;
+}
+
+interface RespostaDeLeads {
+  _embedded?: { leads?: LeadDoKommo[] };
+  _links?: { next?: { href?: string } };
+}
+
+interface RespostaDeFunis {
+  _embedded?: {
+    pipelines?: Array<{
+      id: number;
+      name?: string;
+      _embedded?: { statuses?: Array<{ id: number; name?: string; sort?: number }> };
+    }>;
+  };
+}
+
+function baseDaApi(): string {
+  return `https://${getEnv().KOMMO_SUBDOMAIN}.kommo.com/api/v4`;
+}
+
+function autorizacao(): Record<string, string> {
+  return {
+    authorization: `Bearer ${getEnv().KOMMO_ACCESS_TOKEN}`,
+    accept: "application/json",
+  };
+}
+
+/** Unix em segundos → `YYYY-MM-DD`. */
+function paraDia(unix: number | undefined): string | null {
+  if (!unix) return null;
+  return new Date(unix * 1000).toISOString().slice(0, 10);
+}
+
+/**
+ * O valor de um campo personalizado, pelo código ou pelo nome.
+ *
+ * O Kommo devolve `field_code` só nos campos que ele mesmo criou; os que a
+ * clínica criou à mão têm apenas `field_name`. Procurar pelos dois é o que faz
+ * a UTM aparecer independentemente de como o campo entrou na conta.
+ */
+function campo(lead: LeadDoKommo, nomes: string[]): string | null {
+  const procurados = nomes.map((n) => n.toLowerCase());
+  for (const item of lead.custom_fields_values ?? []) {
+    const identificadores = [item.field_code, item.field_name]
+      .filter((v): v is string => typeof v === "string")
+      .map((v) => v.toLowerCase());
+    if (!identificadores.some((id) => procurados.includes(id))) continue;
+
+    const valor = item.values?.[0]?.value;
+    if (valor === undefined || valor === null || valor === "") continue;
+    return String(valor);
+  }
+  return null;
+}
+
+/**
+ * Uma página por vez, seguindo `_links.next`.
+ *
+ * O Kommo responde **204 sem corpo** quando não há nada na página — que o
+ * `httpJson` entrega como objeto vazio, e o laço encerra sozinho.
+ */
+async function buscarLeads(range: DateRange): Promise<LeadDoKommo[]> {
+  const url = new URL(`${baseDaApi()}/leads`);
+  // Fechamento pode cair fora da janela em que o lead nasceu, então o filtro é
+  // por criação e o corte por data de fechamento acontece depois, em memória.
+  url.searchParams.set(
+    "filter[created_at][from]",
+    String(Date.parse(`${range.from}T00:00:00Z`) / 1000),
+  );
+  url.searchParams.set(
+    "filter[created_at][to]",
+    String(Date.parse(`${range.to}T23:59:59Z`) / 1000),
+  );
+  url.searchParams.set("limit", String(POR_PAGINA));
+
+  const todos: LeadDoKommo[] = [];
+  let proxima: string | null = url.toString();
+
+  for (let pagina = 0; pagina < MAX_PAGINAS && proxima; pagina++) {
+    const resposta: RespostaDeLeads = await httpJson<RespostaDeLeads>(proxima, {
+      headers: autorizacao(),
+    });
+    const leads = resposta._embedded?.leads ?? [];
+    todos.push(...leads);
+    proxima = leads.length === POR_PAGINA ? (resposta._links?.next?.href ?? null) : null;
+  }
+
+  return todos;
+}
+
+/** Nome de cada etapa, por id. Sem isso o funil sairia como números. */
+async function buscarEtapas(): Promise<Map<number, string>> {
+  const nomes = new Map<number, string>();
+  try {
+    const resposta = await httpJson<RespostaDeFunis>(`${baseDaApi()}/leads/pipelines`, {
+      headers: autorizacao(),
+    });
+    for (const funil of resposta._embedded?.pipelines ?? []) {
+      for (const etapa of funil._embedded?.statuses ?? []) {
+        if (etapa.name) nomes.set(etapa.id, etapa.name);
+      }
+    }
+  } catch {
+    // Enfeite: sem os nomes o funil ainda soma, só fica menos legível.
+  }
+  return nomes;
+}
+
+function montarFunil(leads: LeadDoKommo[], nomes: Map<number, string>): TableBlock {
+  const porEtapa = new Map<number, { negocios: number; valor: number }>();
+  for (const lead of leads) {
+    const id = lead.status_id ?? 0;
+    const atual = porEtapa.get(id) ?? { negocios: 0, valor: 0 };
+    atual.negocios += 1;
+    atual.valor += lead.price ?? 0;
+    porEtapa.set(id, atual);
+  }
+
+  return {
+    title: "Negócios por etapa",
+    description: "Onde os negócios do período estão parados, e quanto há em cada etapa.",
+    columns: [
+      { key: "etapa", label: "Etapa", align: "left" },
+      { key: "negocios", label: "Negócios", format: "integer", align: "right" },
+      { key: "valor", label: "Valor", format: "currency", align: "right" },
+    ],
+    rows: [...porEtapa.entries()]
+      .map(([id, dados]) => ({
+        etapa:
+          nomes.get(id) ??
+          (id === GANHO ? "Venda ganha" : id === PERDIDO ? "Perdido" : `Etapa ${id}`),
+        negocios: dados.negocios,
+        valor: Math.round(dados.valor * 100) / 100,
+      }))
+      .sort((a, b) => b.negocios - a.negocios),
+  };
+}
+
+/**
+ * Vendas por origem — o cruzamento que justifica o painel inteiro.
+ *
+ * Só existe se o Kommo estiver recebendo a UTM no negócio. Quando não estiver,
+ * a tabela sai vazia em vez de inventar origem, e o aviso diz o que configurar.
+ */
+function montarOrigens(leads: LeadDoKommo[]): TableBlock {
+  const porOrigem = new Map<string, { leads: number; vendas: number; receita: number }>();
+
+  for (const lead of leads) {
+    const origem =
+      campo(lead, ["utm_source", "utm source", "origem"]) ??
+      (lead.custom_fields_values ? "Sem UTM" : "Sem UTM");
+    const campanha = campo(lead, ["utm_campaign", "utm campaign", "campanha"]);
+    const chave = campanha ? `${origem} · ${campanha}` : origem;
+
+    const atual = porOrigem.get(chave) ?? { leads: 0, vendas: 0, receita: 0 };
+    atual.leads += 1;
+    if (lead.status_id === GANHO) {
+      atual.vendas += 1;
+      atual.receita += lead.price ?? 0;
+    }
+    porOrigem.set(chave, atual);
+  }
+
+  return {
+    title: "Vendas por origem",
+    description: "De onde vieram os negócios que fecharam, pela UTM registrada no Kommo.",
+    columns: [
+      { key: "origem", label: "Origem", align: "left" },
+      { key: "leads", label: "Negócios", format: "integer", align: "right" },
+      { key: "vendas", label: "Ganhos", format: "integer", align: "right" },
+      { key: "taxa", label: "Conversão", format: "percent", align: "right" },
+      { key: "receita", label: "Receita", format: "currency", align: "right" },
+    ],
+    rows: [...porOrigem.entries()]
+      .map(([origem, dados]) => ({
+        origem,
+        leads: dados.leads,
+        vendas: dados.vendas,
+        taxa: dados.leads === 0 ? 0 : dados.vendas / dados.leads,
+        receita: Math.round(dados.receita * 100) / 100,
+      }))
+      .sort((a, b) => b.receita - a.receita || b.vendas - a.vendas),
+  };
+}
+
+export async function fetchVendasReport(range: DateRange): Promise<ChannelReport> {
+  const forceMock = isForceMock();
+
+  if (forceMock || !getCredentials().vendas) {
+    const report = mockVendas(range, new Date().toISOString());
+    report.notices = [
+      avisoOperacao(
+        forceMock
+          ? "Modo mock forçado por QYRA_FORCE_MOCK."
+          : "Sem credencial do Kommo — exibindo dados de demonstração.",
+      ),
+    ];
+    return report;
+  }
+
+  try {
+    const [leads, etapas] = await Promise.all([buscarLeads(range), buscarEtapas()]);
+
+    const ganhos = leads.filter((l) => l.status_id === GANHO);
+    const receita = ganhos.reduce((acc, l) => acc + (l.price ?? 0), 0);
+    const emAberto = leads.filter((l) => l.status_id !== GANHO && l.status_id !== PERDIDO);
+
+    // Ciclo médio só considera quem fechou e tem as duas pontas: sem
+    // `closed_at`, incluir o negócio arrastaria a média para baixo.
+    const ciclos = ganhos
+      .filter((l) => l.closed_at && l.created_at)
+      .map((l) => ((l.closed_at as number) - (l.created_at as number)) / 86_400);
+    const cicloMedio = ciclos.length === 0 ? 0 : ciclos.reduce((a, b) => a + b, 0) / ciclos.length;
+
+    const porDia = new Map<string, { vendas: number; receita: number; leads: number }>();
+    for (const lead of leads) {
+      const criado = paraDia(lead.created_at);
+      if (criado) {
+        const atual = porDia.get(criado) ?? { vendas: 0, receita: 0, leads: 0 };
+        atual.leads += 1;
+        porDia.set(criado, atual);
+      }
+      // A venda conta no dia em que fechou, não no dia em que o lead nasceu —
+      // é a diferença entre "quanto entrou" e "quanto vendemos" no dia.
+      if (lead.status_id === GANHO) {
+        const fechado = paraDia(lead.closed_at) ?? criado;
+        if (!fechado) continue;
+        const atual = porDia.get(fechado) ?? { vendas: 0, receita: 0, leads: 0 };
+        atual.vendas += 1;
+        atual.receita += lead.price ?? 0;
+        porDia.set(fechado, atual);
+      }
+    }
+
+    const series: SeriesPoint[] = eachDay(range).map((date) => {
+      const dia = porDia.get(date) ?? { vendas: 0, receita: 0, leads: 0 };
+      return {
+        date,
+        vendas: dia.vendas,
+        receita: Math.round(dia.receita * 100) / 100,
+        leads: dia.leads,
+      };
+    });
+
+    const semUtm = leads.every((l) => campo(l, ["utm_source", "utm source", "origem"]) === null);
+
+    return {
+      channel: "vendas",
+      label: "Vendas",
+      source: "live",
+      range,
+      fetchedAt: new Date().toISOString(),
+      kpis: [
+        { key: "vendas", label: "Vendas ganhas", value: ganhos.length, format: "integer" },
+        {
+          key: "receita",
+          label: "Receita",
+          value: Math.round(receita * 100) / 100,
+          format: "currency",
+        },
+        {
+          key: "ticket",
+          label: "Ticket médio",
+          value: ganhos.length === 0 ? 0 : receita / ganhos.length,
+          format: "currency",
+        },
+        {
+          key: "conversao",
+          label: "Lead vira venda",
+          value: leads.length === 0 ? 0 : ganhos.length / leads.length,
+          format: "percent",
+          hint: "Negócios ganhos sobre todos os negócios criados no período.",
+        },
+        {
+          key: "ciclo",
+          label: "Ciclo de fechamento",
+          value: cicloMedio,
+          format: "decimal",
+          lowerIsBetter: true,
+          hint: "Dias entre a criação do negócio e o fechamento, na média dos que fecharam.",
+        },
+        { key: "emAberto", label: "Em aberto", value: emAberto.length, format: "integer" },
+      ],
+      series,
+      seriesDefs: [
+        { key: "receita", label: "Receita", format: "currency", slot: 5 },
+        { key: "vendas", label: "Vendas", format: "integer", slot: 2 },
+      ],
+      tables: [montarFunil(leads, etapas), montarOrigens(leads)],
+      notices:
+        semUtm && leads.length > 0
+          ? [
+              avisoOperacao(
+                "Nenhum negócio do Kommo traz UTM. Sem isso não dá para ligar venda a campanha — é preciso o formulário gravar utm_source e utm_campaign no negócio.",
+              ),
+            ]
+          : [],
+    };
+  } catch (erro) {
+    const report = mockVendas(range, new Date().toISOString());
+    report.notices = [
+      avisoOperacao(`O Kommo não respondeu. Detalhe técnico: ${descreverFalha(erro)}`),
+    ];
+    return report;
+  }
+}

--- a/src/server/connectors/kommo.ts
+++ b/src/server/connectors/kommo.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { avisoOperacao } from "@/lib/avisos";
 import { eachDay } from "@/lib/date-range";
-import type { ChannelReport, DateRange, SeriesPoint, TableBlock } from "@/lib/types";
+import type { ChannelReport, DateRange, Notice, SeriesPoint, TableBlock } from "@/lib/types";
 import { mockVendas } from "@/mocks/reports";
 import { getCredentials, getEnv, isForceMock } from "@/server/env";
 import { descreverFalha, httpJson } from "@/server/lib/http";
@@ -135,6 +135,30 @@ async function buscarLeads(range: DateRange): Promise<LeadDoKommo[]> {
   return todos;
 }
 
+/**
+ * Quantos negócios estão na área de "leads de entrada".
+ *
+ * O Kommo trata o que ainda não foi organizado como uma coisa à parte: esses
+ * registros **não aparecem em `/leads`**, e sem contá-los o funil começa
+ * mentindo — some justamente o topo, que é por onde tudo entra.
+ *
+ * Aqui só o número interessa. O formato desses registros difere do de um
+ * negócio comum, e adivinhar a forma para extrair valor renderia um total
+ * inventado.
+ */
+async function contarLeadsDeEntrada(): Promise<number> {
+  try {
+    const resposta = await httpJson<{ _embedded?: { unsorted?: unknown[] } }>(
+      `${baseDaApi()}/leads/unsorted?limit=${POR_PAGINA}`,
+      { headers: autorizacao() },
+    );
+    return resposta._embedded?.unsorted?.length ?? 0;
+  } catch {
+    // A área pode estar vazia (204) ou o escopo não cobrir: some da tabela.
+    return 0;
+  }
+}
+
 /** Nome de cada etapa, por id. Sem isso o funil sairia como números. */
 async function buscarEtapas(): Promise<Map<number, string>> {
   const nomes = new Map<number, string>();
@@ -153,7 +177,11 @@ async function buscarEtapas(): Promise<Map<number, string>> {
   return nomes;
 }
 
-function montarFunil(leads: LeadDoKommo[], nomes: Map<number, string>): TableBlock {
+function montarFunil(
+  leads: LeadDoKommo[],
+  nomes: Map<number, string>,
+  deEntrada: number,
+): TableBlock {
   const porEtapa = new Map<number, { negocios: number; valor: number }>();
   for (const lead of leads) {
     const id = lead.status_id ?? 0;
@@ -179,6 +207,13 @@ function montarFunil(leads: LeadDoKommo[], nomes: Map<number, string>): TableBlo
         negocios: dados.negocios,
         valor: Math.round(dados.valor * 100) / 100,
       }))
+      .concat(
+        // No topo da lista e fora da ordenação: é a porta de entrada, não uma
+        // etapa concorrendo por volume.
+        deEntrada > 0
+          ? [{ etapa: "Leads de entrada (a organizar)", negocios: deEntrada, valor: 0 }]
+          : [],
+      )
       .sort((a, b) => b.negocios - a.negocios),
   };
 }
@@ -246,7 +281,11 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
   }
 
   try {
-    const [leads, etapas] = await Promise.all([buscarLeads(range), buscarEtapas()]);
+    const [leads, etapas, deEntrada] = await Promise.all([
+      buscarLeads(range),
+      buscarEtapas(),
+      contarLeadsDeEntrada(),
+    ]);
 
     const ganhos = leads.filter((l) => l.status_id === GANHO);
     const receita = ganhos.reduce((acc, l) => acc + (l.price ?? 0), 0);
@@ -291,6 +330,27 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
 
     const semUtm = leads.every((l) => campo(l, ["utm_source", "utm source", "origem"]) === null);
 
+    // Negócio ganho sem valor preenchido é o caso mais traiçoeiro deste
+    // conector: receita e ticket saem R$ 0,00 sem estar errados, e quem olha
+    // lê "não vendemos nada" quando o certo é "ninguém preencheu o valor".
+    const semValor = ganhos.length > 0 && receita === 0;
+
+    const avisos: Notice[] = [];
+    if (semValor) {
+      avisos.push(
+        avisoOperacao(
+          `${ganhos.length} negócio(s) ganho(s) no período estão sem valor preenchido no Kommo. Receita e ticket médio ficam em zero até o campo de valor ser preenchido ao fechar a venda.`,
+        ),
+      );
+    }
+    if (semUtm && leads.length > 0) {
+      avisos.push(
+        avisoOperacao(
+          "Nenhum negócio do Kommo traz UTM. Sem isso não dá para ligar venda a campanha — é preciso o formulário ou a automação gravar utm_source e utm_campaign no negócio.",
+        ),
+      );
+    }
+
     return {
       channel: "vendas",
       label: "Vendas",
@@ -304,6 +364,9 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
           label: "Receita",
           value: Math.round(receita * 100) / 100,
           format: "currency",
+          hint: semValor
+            ? "Zero porque os negócios ganhos estão sem valor preenchido no Kommo, não porque não houve venda."
+            : undefined,
         },
         {
           key: "ticket",
@@ -333,15 +396,8 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
         { key: "receita", label: "Receita", format: "currency", slot: 5 },
         { key: "vendas", label: "Vendas", format: "integer", slot: 2 },
       ],
-      tables: [montarFunil(leads, etapas), montarOrigens(leads)],
-      notices:
-        semUtm && leads.length > 0
-          ? [
-              avisoOperacao(
-                "Nenhum negócio do Kommo traz UTM. Sem isso não dá para ligar venda a campanha — é preciso o formulário gravar utm_source e utm_campaign no negócio.",
-              ),
-            ]
-          : [],
+      tables: [montarFunil(leads, etapas, deEntrada), montarOrigens(leads)],
+      notices: avisos,
     };
   } catch (erro) {
     const report = mockVendas(range, new Date().toISOString());

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -91,6 +91,12 @@ const schema = z.object({
   // Token da API de exportação do Clarity. Esse é segredo, ao contrário do ID.
   CLARITY_API_TOKEN: optionalString,
 
+  // ---- Kommo (CRM de vendas) ----
+  /** O nome que aparece na URL da conta: `https://SUBDOMINIO.kommo.com`. */
+  KOMMO_SUBDOMAIN: optionalString,
+  /** Chave de longa duração da integração privada. */
+  KOMMO_ACCESS_TOKEN: optionalString,
+
   /** Janela e teto do rate limit das rotas de API. */
   RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
   RATE_LIMIT_MAX: z.coerce.number().int().positive().default(60),
@@ -134,6 +140,7 @@ export interface Credentials {
   googleAds: boolean;
   ga4: boolean;
   clarity: boolean;
+  vendas: boolean;
 }
 
 /** Quais integrações têm credencial completa **agora**. */
@@ -157,5 +164,7 @@ export function getCredentials(): Credentials {
     googleAds: Boolean(google && env.GOOGLE_ADS_DEVELOPER_TOKEN && env.GOOGLE_ADS_CUSTOMER_ID),
     ga4: Boolean(google && env.GA4_PROPERTY_ID),
     clarity: Boolean(env.CLARITY_API_TOKEN),
+    // As duas juntas: o token sem o subdomínio não sabe para qual conta ir.
+    vendas: Boolean(env.KOMMO_SUBDOMAIN && env.KOMMO_ACCESS_TOKEN),
   };
 }

--- a/src/server/lib/http.ts
+++ b/src/server/lib/http.ts
@@ -52,6 +52,21 @@ export function redactSecrets(text: string): string {
   );
 }
 
+/**
+ * Resumo curto de um erro, para virar aviso na tela.
+ *
+ * Passa pelo `redactSecrets` porque a resposta das plataformas costuma ecoar a
+ * requisição, e a requisição leva token. Mora aqui, e não no conector, porque
+ * todo conector precisa da mesma coisa — e duplicar significaria um deles
+ * esquecer a redação um dia.
+ */
+export function descreverFalha(erro: unknown): string {
+  const bruto = erro instanceof Error ? erro.message : String(erro);
+  const corpo = (erro as HttpError)?.body;
+  const texto = redactSecrets(typeof corpo === "string" && corpo ? `${bruto} — ${corpo}` : bruto);
+  return texto.length > 240 ? `${texto.slice(0, 240)}…` : texto;
+}
+
 const RETRYABLE = new Set([408, 425, 429, 500, 502, 503, 504]);
 
 function backoffMs(attempt: number): number {

--- a/src/server/reports.ts
+++ b/src/server/reports.ts
@@ -18,6 +18,7 @@ import { cached } from "@/server/lib/cache";
 import { fetchClarityResumo } from "./connectors/clarity";
 import { fetchGa4Report } from "./connectors/ga4";
 import { fetchGoogleAdsReport } from "./connectors/google-ads";
+import { fetchVendasReport } from "./connectors/kommo";
 import { fetchMetaAdsReport } from "./connectors/meta-ads";
 import { fetchOrganicoReport } from "./connectors/organico";
 
@@ -46,6 +47,7 @@ const FETCHERS: Record<ChannelId, (range: DateRange) => Promise<ChannelReport>> 
   "google-ads": fetchGoogleAdsReport,
   ga4: fetchGa4Report,
   organico: fetchOrganicoReport,
+  vendas: fetchVendasReport,
 };
 
 function cacheKey(channel: ChannelId, range: DateRange): string {

--- a/tests/integration/kommo.test.ts
+++ b/tests/integration/kommo.test.ts
@@ -184,6 +184,66 @@ describe("vendas pelo Kommo", () => {
     expect(report.notices.every((n) => n.audience === "operacao")).toBe(true);
   });
 
+  it("venda ganha sem valor avisa em vez de deixar o zero sozinho", async () => {
+    const { report } = await relatorio([
+      // É o estado real da conta: negócio movido para ganho, campo de valor
+      // nunca preenchido.
+      { id: 1, status_id: GANHO, created_at: emSegundos("2026-02-03T10:00:00Z") },
+      { id: 2, status_id: GANHO, created_at: emSegundos("2026-02-04T10:00:00Z") },
+    ]);
+
+    expect(kpi(report, "vendas")).toBe(2);
+    expect(kpi(report, "receita")).toBe(0);
+    // Zero sem explicação lê como "não vendemos nada", que é o oposto do fato.
+    expect(report.kpis.find((k) => k.key === "receita")?.hint).toMatch(/sem valor preenchido/i);
+    expect(report.notices.some((n) => /valor preenchido/i.test(n.text))).toBe(true);
+  });
+
+  it("não inventa aviso de valor quando a receita existe", async () => {
+    const { report } = await relatorio([
+      { id: 1, price: 500, status_id: GANHO, created_at: emSegundos("2026-02-03T10:00:00Z") },
+    ]);
+
+    expect(report.kpis.find((k) => k.key === "receita")?.hint).toBeUndefined();
+    expect(report.notices.some((n) => /valor preenchido/i.test(n.text))).toBe(false);
+  });
+
+  it("conta os leads de entrada, que não vêm em /leads", async () => {
+    const chamadas = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/leads/unsorted")) {
+        return new Response(JSON.stringify({ _embedded: { unsorted: [{}, {}, {}] } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("/leads/pipelines")) {
+        return new Response(JSON.stringify({ _embedded: { pipelines: [] } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          _embedded: {
+            leads: [{ id: 1, status_id: 20, created_at: emSegundos("2026-02-03T10:00:00Z") }],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", chamadas);
+
+    const { fetchVendasReport } = await import("@/server/connectors/kommo");
+    const report = await fetchVendasReport(RANGE);
+    const funil = report.tables.find((t) => t.title === "Negócios por etapa");
+
+    // Sem essa linha o funil perde o topo — é por ali que tudo entra.
+    expect(funil?.rows.find((r) => String(r.etapa).startsWith("Leads de entrada"))?.negocios).toBe(
+      3,
+    );
+  });
+
   it("usa o nome real da etapa, e não o número", async () => {
     const { report } = await relatorio(
       [{ id: 1, status_id: 77, created_at: emSegundos("2026-02-03T10:00:00Z") }],

--- a/tests/integration/kommo.test.ts
+++ b/tests/integration/kommo.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Vendas pelo Kommo.
+ *
+ * O que este conector faz de diferente dos outros: ele lê **dinheiro**. Um erro
+ * de contagem aqui não deixa a tela feia — faz a clínica decidir orçamento com
+ * o número errado.
+ */
+
+const RANGE = { from: "2026-02-01", to: "2026-02-28" };
+const CREDENCIAIS = { KOMMO_SUBDOMAIN: "qyra", KOMMO_ACCESS_TOKEN: "chave" };
+
+const GANHO = 142;
+const PERDIDO = 143;
+
+/** Unix em segundos, que é a unidade do Kommo. */
+function emSegundos(iso: string): number {
+  return Math.floor(Date.parse(iso) / 1000);
+}
+
+interface LeadFalso {
+  id: number;
+  price?: number;
+  status_id?: number;
+  created_at?: number;
+  closed_at?: number;
+  custom_fields_values?: Array<{ field_name?: string; values?: Array<{ value?: string }> }>;
+}
+
+function kommo(leads: LeadFalso[], etapas: Array<{ id: number; name: string }> = []) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    if (url.includes("/leads/pipelines")) {
+      return new Response(
+        JSON.stringify({ _embedded: { pipelines: [{ id: 1, _embedded: { statuses: etapas } }] } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    return new Response(JSON.stringify({ _embedded: { leads } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+}
+
+async function relatorio(leads: LeadFalso[], etapas?: Array<{ id: number; name: string }>) {
+  const chamadas = kommo(leads, etapas);
+  vi.stubGlobal("fetch", chamadas);
+  const { fetchVendasReport } = await import("@/server/connectors/kommo");
+  return { report: await fetchVendasReport(RANGE), chamadas };
+}
+
+const kpi = (r: Awaited<ReturnType<typeof relatorio>>["report"], chave: string) =>
+  r.kpis.find((k) => k.key === chave)?.value ?? 0;
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+  vi.stubEnv("QYRA_FORCE_MOCK", "false");
+  for (const [k, v] of Object.entries(CREDENCIAIS)) vi.stubEnv(k, v);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe("vendas pelo Kommo", () => {
+  it("só conta como receita o negócio ganho", async () => {
+    const { report } = await relatorio([
+      { id: 1, price: 1000, status_id: GANHO, created_at: emSegundos("2026-02-03T10:00:00Z") },
+      { id: 2, price: 5000, status_id: PERDIDO, created_at: emSegundos("2026-02-04T10:00:00Z") },
+      { id: 3, price: 9000, status_id: 20, created_at: emSegundos("2026-02-05T10:00:00Z") },
+    ]);
+
+    // Somar o negócio em aberto ou o perdido daria R$ 15.000 de receita que
+    // não existe — e um ticket médio inventado junto.
+    expect(kpi(report, "vendas")).toBe(1);
+    expect(kpi(report, "receita")).toBe(1000);
+    expect(kpi(report, "ticket")).toBe(1000);
+    expect(kpi(report, "emAberto")).toBe(1);
+  });
+
+  it("a taxa de conversão usa todos os negócios como base", async () => {
+    const { report } = await relatorio([
+      { id: 1, price: 100, status_id: GANHO, created_at: emSegundos("2026-02-03T10:00:00Z") },
+      { id: 2, status_id: PERDIDO, created_at: emSegundos("2026-02-03T10:00:00Z") },
+      { id: 3, status_id: 20, created_at: emSegundos("2026-02-03T10:00:00Z") },
+      { id: 4, status_id: 20, created_at: emSegundos("2026-02-03T10:00:00Z") },
+    ]);
+
+    expect(kpi(report, "conversao")).toBeCloseTo(0.25, 6);
+  });
+
+  it("a venda entra no dia em que fechou, não no dia em que o lead nasceu", async () => {
+    const { report } = await relatorio([
+      {
+        id: 1,
+        price: 2000,
+        status_id: GANHO,
+        created_at: emSegundos("2026-02-02T10:00:00Z"),
+        closed_at: emSegundos("2026-02-20T10:00:00Z"),
+      },
+    ]);
+
+    const nascimento = report.series.find((p) => p.date === "2026-02-02");
+    const fechamento = report.series.find((p) => p.date === "2026-02-20");
+
+    // "Quanto entrou" e "quanto vendemos" são perguntas diferentes: creditar a
+    // venda no dia da criação faria a série de receita mentir sobre o caixa.
+    expect(nascimento?.leads).toBe(1);
+    expect(nascimento?.receita).toBe(0);
+    expect(fechamento?.receita).toBe(2000);
+    expect(fechamento?.vendas).toBe(1);
+  });
+
+  it("o ciclo médio ignora quem não fechou", async () => {
+    const { report } = await relatorio([
+      {
+        id: 1,
+        price: 100,
+        status_id: GANHO,
+        created_at: emSegundos("2026-02-01T00:00:00Z"),
+        closed_at: emSegundos("2026-02-11T00:00:00Z"),
+      },
+      // Sem `closed_at`: entrar na média com zero puxaria o ciclo para baixo.
+      { id: 2, status_id: 20, created_at: emSegundos("2026-02-01T00:00:00Z") },
+    ]);
+
+    expect(kpi(report, "ciclo")).toBeCloseTo(10, 3);
+  });
+
+  it("agrupa por UTM quando o negócio traz o campo", async () => {
+    const utm = (source: string, campanha: string) => [
+      { field_name: "utm_source", values: [{ value: source }] },
+      { field_name: "utm_campaign", values: [{ value: campanha }] },
+    ];
+
+    const { report } = await relatorio([
+      {
+        id: 1,
+        price: 3000,
+        status_id: GANHO,
+        created_at: emSegundos("2026-02-03T10:00:00Z"),
+        custom_fields_values: utm("meta", "emagrecimento"),
+      },
+      {
+        id: 2,
+        status_id: PERDIDO,
+        created_at: emSegundos("2026-02-03T10:00:00Z"),
+        custom_fields_values: utm("meta", "emagrecimento"),
+      },
+      {
+        id: 3,
+        price: 1000,
+        status_id: GANHO,
+        created_at: emSegundos("2026-02-03T10:00:00Z"),
+        custom_fields_values: utm("google", "marca"),
+      },
+    ]);
+
+    const origens = report.tables.find((t) => t.title === "Vendas por origem");
+    const meta = origens?.rows.find((r) => String(r.origem).startsWith("meta"));
+
+    expect(meta?.leads).toBe(2);
+    expect(meta?.vendas).toBe(1);
+    expect(meta?.receita).toBe(3000);
+    expect(meta?.taxa).toBeCloseTo(0.5, 6);
+  });
+
+  it("sem UTM nenhuma, avisa em vez de inventar origem", async () => {
+    const { report } = await relatorio([
+      { id: 1, price: 100, status_id: GANHO, created_at: emSegundos("2026-02-03T10:00:00Z") },
+    ]);
+
+    // O aviso é de operação: quem abre o painel não precisa vê-lo, quem
+    // configura precisa.
+    expect(report.notices.some((n) => /UTM/i.test(n.text))).toBe(true);
+    expect(report.notices.every((n) => n.audience === "operacao")).toBe(true);
+  });
+
+  it("usa o nome real da etapa, e não o número", async () => {
+    const { report } = await relatorio(
+      [{ id: 1, status_id: 77, created_at: emSegundos("2026-02-03T10:00:00Z") }],
+      [{ id: 77, name: "Avaliação agendada" }],
+    );
+
+    const funil = report.tables.find((t) => t.title === "Negócios por etapa");
+    expect(funil?.rows[0]?.etapa).toBe("Avaliação agendada");
+  });
+
+  it("sem credencial, cai em demonstração em vez de quebrar", async () => {
+    vi.stubEnv("KOMMO_ACCESS_TOKEN", "");
+    vi.resetModules();
+    vi.stubGlobal("fetch", kommo([]));
+
+    const { fetchVendasReport } = await import("@/server/connectors/kommo");
+    const report = await fetchVendasReport(RANGE);
+
+    expect(report.source).toBe("mock");
+    expect(report.notices.some((n) => /demonstração/i.test(n.text))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — pedido direto: aba de vendas integrada ao Kommo. Abro a
Issue (Nova função) referenciando este PR.

## O que muda no painel

Os quatro canais param no lead. Esta tela responde o que vem depois: **quanto
daquilo virou dinheiro, em quanto tempo, e vindo de onde.**

| Bloco | Conteúdo |
|---|---|
| Indicadores | Vendas ganhas, receita, ticket médio, lead→venda, ciclo de fechamento, em aberto |
| Série diária | Receita e vendas, cada uma na própria escala |
| Funil | Negócios por etapa, com o nome real vindo do Kommo |
| Origem | Vendas por UTM — negócios, ganhos, conversão e receita |

## Onde ela se encaixa

`vendas` entra em `CHANNEL_IDS` mas fica **fora de `CHANNELS`**, de propósito.

É um relatório completo — período, série, indicadores, tabelas — e por isso
reaproveita a mesma tela dos canais sem uma linha de UI nova. Mas **não é canal
de aquisição**: não tem investimento, e somar receita ao total de mídia na visão
geral produziria um número sem significado. A consolidação segue iterando
`CHANNELS`, então a visão geral não muda.

## Três decisões de contagem

Não são detalhe: cada uma muda o número que aparece na tela.

**Só negócio ganho vira receita.** Somar o que está em aberto ou perdido
inflaria o faturamento — e inventaria um ticket médio junto. Um teste cobre
exatamente isso: R$ 15.000 em aberto/perdido não podem virar receita.

**A venda conta no dia em que fechou, não no dia em que o lead nasceu.** "Quanto
entrou" e "quanto vendemos" são perguntas diferentes; creditar na criação faria
a série de receita mentir sobre o caixa.

**O ciclo médio ignora quem não fechou.** Negócio sem `closed_at` entraria na
média como zero, que não é medição — é ausência dela.

## A UTM é o que liga venda a campanha

Sem `utm_source` e `utm_campaign` gravados **no negócio**, a tela mostra receita
e ticket, mas não diz **qual campanha gerou a venda** — que é a pergunta que
justifica o painel inteiro.

Isso depende de configuração no Kommo, não de código aqui. O conector procura
por `utm_source`/`utm_campaign` e também por `origem`/`campanha`, então campo em
português funciona. Quando nenhum negócio traz UTM, o aviso é de **operação**:
quem opera precisa ver, quem abre o painel na reunião não.

## Também neste PR

**`descreverFalha` saiu do conector do Google Ads para `server/lib/http.ts`.**
Todo conector precisa do mesmo resumo de erro redigido, e duplicar significaria
um deles esquecer a redação de segredo um dia.

**O modo de demonstração ficou coerente.** O funil e a tabela de origem passam a
sair dos mesmos totais dos indicadores. Antes as fatias eram soltas e o funil
mostrava "Venda ganha: 64" com "48 vendas ganhas" no topo — isso lê como erro de
cálculo, não como dado fictício.

## Como foi validado

- [x] `npm run verify` — **215 testes** (8 novos), lint, tipos e contrato de arquitetura
- [x] `npm run test:e2e` — 34/34
- [x] `npm run build` — `/vendas` aparece como `ƒ` (dinâmica)
- [x] Conferido no navegador a 1440px, sem estouro horizontal

Os testes cobrem: receita só de negócio ganho; base da taxa de conversão;
crédito da venda no dia do fechamento; ciclo ignorando quem não fechou;
agrupamento por UTM; o aviso quando não há UTM; nome de etapa vindo da API; e a
queda para demonstração sem credencial.

## Riscos e limitações

**Nada exercitado contra a conta real.** O acesso a este ambiente é bloqueado,
então a documentação da API não pôde ser consultada durante o desenvolvimento —
o conector segue os formatos conhecidos da API v4 (envelope `_embedded`,
paginação por `_links.next`, Unix em segundos, `142`/`143` como ganho/perdido).
**Se algo divergir, a tela cai em demonstração com o motivo no aviso, em vez de
quebrar.** É o mesmo desenho dos outros conectores.

**Os rótulos da interface do Kommo** citados na documentação precisam de
conferência — a navegação muda de nome entre versões.

**Paginação com teto de 20 páginas** (5.000 negócios no período). Acima disso o
relatório fica incompleto sem avisar; cobre com folga o volume atual, mas é uma
dívida registrada.

**Dado pessoal.** Negócios do CRM carregam nome de paciente. Este PR **não** traz
nome nenhum para a tela — só agregados —, mas o passo seguinte natural (listar
negócios recentes) traria, e aí a proteção do painel deixa de ser sobre gasto de
mídia e passa a ser sobre dado de saúde.

## Próximos passos

- Cruzar investimento de mídia com receita: **CAC real e ROI** por campanha, na
  visão geral. É o que a tabela de origem já prepara
- Vendas por responsável, quando fizer sentido acompanhar equipe
- Conferir os nomes de campo de UTM contra a conta real

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_