### PR TITLE
feat: salvar senha no navegador, e conserta um bug que quebraria o login em produção

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -36,6 +36,13 @@ const CONFIGURAVEIS = [
   "CLARITY_PROJECT_ID",
   "CLARITY_API_TOKEN",
   "QYRA_FORCE_MOCK",
+  // A senha de acesso. Só a presença — o valor nunca sai daqui. Sem ela na
+  // lista, a variável mais importante do painel era a única que ninguém
+  // conseguia conferir.
+  "QYRA_SENHA",
+  "QYRA_SESSAO_SECRET",
+  "KOMMO_SUBDOMAIN",
+  "KOMMO_ACCESS_TOKEN",
 ] as const;
 
 /**

--- a/src/app/api/sessao/route.ts
+++ b/src/app/api/sessao/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse } from "next/server";
+
+import {
+  COOKIE_DA_SESSAO,
+  criarToken,
+  DURACAO_DA_SESSAO_MS,
+  senhaConfere,
+} from "@/server/auth/sessao";
+import { rateLimit } from "@/server/lib/rate-limit";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Entrada no painel, por envio de formulário de verdade.
+ *
+ * Era uma Server Action, e funcionava — mas o gerenciador de senha do
+ * navegador nunca oferecia guardar a senha. Server Action envia por
+ * JavaScript, sem navegação, e é a navegação que o Chrome usa como sinal de
+ * "alguém acabou de entrar em algum lugar". Formulário nativo com resposta
+ * 303 devolve esse sinal, e a senha passa a caber no gerenciador — que é
+ * exatamente onde uma senha compartilhada deve morar.
+ *
+ * A troca custa a proteção que o Next dava de graça contra formulário postado
+ * de outro site. Ela volta aqui, explícita, na conferência de origem.
+ */
+
+/** Dez tentativas a cada dez minutos, por IP. */
+const TENTATIVAS = 10;
+const JANELA_MS = 10 * 60 * 1000;
+
+/**
+ * Só caminho interno pode virar destino.
+ *
+ * Sem esta peneira, `?de=https://outro-site` transformaria o login num
+ * redirecionador aberto — o golpe clássico de phishing, em que o link começa
+ * no domínio confiável e termina em outro lugar. `//` no início é o mesmo
+ * ataque escrito de outro jeito: o navegador lê como endereço absoluto.
+ */
+function destinoSeguro(bruto: string): string | null {
+  if (!bruto.startsWith("/") || bruto.startsWith("//")) return null;
+  return bruto;
+}
+
+/**
+ * O formulário partiu deste mesmo site?
+ *
+ * É o que a Server Action conferia sozinha. Sem isso, outra página poderia
+ * postar senhas aqui em nome de quem estivesse com a aba aberta — e cada
+ * tentativa consumiria o teto de um IP que não é o do atacante.
+ *
+ * Ausência de origem reprova: navegador que envia formulário sempre manda
+ * `origin`, e `referer` cobre os poucos casos em que não manda.
+ */
+function mesmaOrigem(request: Request): boolean {
+  const declarada = request.headers.get("origin") ?? request.headers.get("referer");
+  if (!declarada) return false;
+
+  const anfitriao = request.headers.get("host");
+  if (!anfitriao) return false;
+
+  try {
+    return new URL(declarada).host === anfitriao;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A requisição chegou por https?
+ *
+ * Sem o cabeçalho não dá para saber — aí o modo de build decide, que é o
+ * palpite conservador: em produção assume https.
+ */
+function emHttps(protocolo: string | null): boolean {
+  if (!protocolo) return process.env.NODE_ENV === "production";
+  return protocolo.split(",")[0].trim() === "https";
+}
+
+function paraLogin(destino: string | null, erro?: string): string {
+  const query = new URLSearchParams();
+  if (destino) query.set("de", destino);
+  if (erro) query.set("erro", erro);
+  const busca = query.toString();
+  return busca ? `/login?${busca}` : "/login";
+}
+
+/**
+ * Redirecionamento com destino **relativo**.
+ *
+ * `NextResponse.redirect` exige URL absoluta, e montá-la a partir de
+ * `request.url` foi um bug real: pedindo `127.0.0.1`, o destino saía como
+ * `localhost` — outra origem, e a CSP `form-action \'self\'` recusava o envio,
+ * com o login parado sem explicação. Em produção seria pior: a URL interna do
+ * deploy no lugar do domínio do cliente.
+ *
+ * `Location` relativo não tem esse problema: o navegador resolve contra o
+ * endereço que ele mesmo pediu, e o destino é a mesma origem por construção.
+ *
+ * 303 e não 302: obriga o navegador a trocar o POST por um GET no destino.
+ * Sem isso, recarregar a página reenviaria a senha.
+ */
+function verPara(caminho: string): NextResponse {
+  return new NextResponse(null, { status: 303, headers: { location: caminho } });
+}
+
+export async function POST(request: Request) {
+  const formulario = await request.formData();
+  const senha = String(formulario.get("senha") ?? "");
+  const destino = destinoSeguro(String(formulario.get("de") ?? ""));
+
+  if (!mesmaOrigem(request)) {
+    return verPara(paraLogin(destino, "origem"));
+  }
+
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0].trim() ??
+    request.headers.get("x-real-ip") ??
+    "anon";
+
+  // Senha compartilhada é curta por natureza; sem teto de tentativas, um script
+  // a percorre inteira em minutos.
+  if (!rateLimit(`login:${ip}`, TENTATIVAS, JANELA_MS).ok) {
+    return verPara(paraLogin(destino, "espera"));
+  }
+
+  if (!senhaConfere(senha)) {
+    return verPara(paraLogin(destino, "senha"));
+  }
+
+  const token = await criarToken();
+  if (!token) return verPara(paraLogin(destino, "config"));
+
+  const resposta = verPara(destino ?? "/");
+  resposta.cookies.set(COOKIE_DA_SESSAO, token, {
+    // Fora do alcance de qualquer script na página: um XSS não leva a sessão junto.
+    httpOnly: true,
+    // `secure` segue o protocolo real da requisição, não o modo de build: em
+    // http um cookie `secure` não volta, e o login entraria em laço.
+    secure: emHttps(request.headers.get("x-forwarded-proto")),
+    // `lax` deixa o link compartilhado funcionar e ainda barra POST de fora.
+    sameSite: "lax",
+    path: "/",
+    maxAge: Math.floor(DURACAO_DA_SESSAO_MS / 1000),
+  });
+
+  return resposta;
+}

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -1,100 +1,18 @@
 "use server";
 
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
-import {
-  COOKIE_DA_SESSAO,
-  criarToken,
-  DURACAO_DA_SESSAO_MS,
-  senhaConfere,
-} from "@/server/auth/sessao";
-import { rateLimit } from "@/server/lib/rate-limit";
+import { COOKIE_DA_SESSAO } from "@/server/auth/sessao";
 
 /**
- * Entrada no painel.
+ * Saída do painel.
  *
- * Server Action em vez de rota de API: o Next confere a origem da requisição
- * sozinho, o que fecha a porta para outro site postar o formulário no lugar da
- * pessoa. E funciona sem JavaScript — se o script falhar, a senha ainda entra.
+ * A entrada mora em `/api/sessao`, como formulário nativo, para o gerenciador
+ * de senha do navegador reconhecê-la. Sair não precisa disso: é um clique
+ * dentro de uma página já autenticada, e Server Action confere a origem
+ * sozinha.
  */
-
-/** Dez tentativas a cada dez minutos, por IP. */
-const TENTATIVAS = 10;
-const JANELA_MS = 10 * 60 * 1000;
-
-/**
- * Só caminho interno pode virar destino.
- *
- * Sem esta peneira, `?de=https://outro-site` transformaria o login num
- * redirecionador aberto — o golpe clássico de phishing, em que o link começa
- * no domínio confiável e termina em outro lugar. `//` no início é o mesmo
- * ataque escrito de outro jeito: o navegador lê como endereço absoluto.
- */
-function destinoSeguro(bruto: string): string | null {
-  if (!bruto.startsWith("/") || bruto.startsWith("//")) return null;
-  return bruto;
-}
-
-/**
- * A requisição chegou por https?
- *
- * Sem o cabeçalho não dá para saber — aí o modo de build decide, que é o
- * palpite conservador: em produção assume https.
- */
-function emHttps(protocolo: string | null): boolean {
-  if (!protocolo) return process.env.NODE_ENV === "production";
-  return protocolo.split(",")[0].trim() === "https";
-}
-
-function paraLogin(destino: string | null, erro?: string): string {
-  const query = new URLSearchParams();
-  if (destino) query.set("de", destino);
-  if (erro) query.set("erro", erro);
-  const busca = query.toString();
-  return busca ? `/login?${busca}` : "/login";
-}
-
-export async function entrar(formData: FormData) {
-  const senha = String(formData.get("senha") ?? "");
-  const destino = destinoSeguro(String(formData.get("de") ?? ""));
-
-  const cabecalhos = await headers();
-  const ip =
-    cabecalhos.get("x-forwarded-for")?.split(",")[0].trim() ??
-    cabecalhos.get("x-real-ip") ??
-    "anon";
-
-  // Senha compartilhada é curta por natureza; sem teto de tentativas, um script
-  // a percorre inteira em minutos.
-  if (!rateLimit(`login:${ip}`, TENTATIVAS, JANELA_MS).ok) {
-    redirect(paraLogin(destino, "espera"));
-  }
-
-  if (!senhaConfere(senha)) {
-    redirect(paraLogin(destino, "senha"));
-  }
-
-  const token = await criarToken();
-  if (!token) redirect(paraLogin(destino, "config"));
-
-  const jar = await cookies();
-  jar.set(COOKIE_DA_SESSAO, token, {
-    // Fora do alcance de qualquer script na página: um XSS não leva a sessão junto.
-    httpOnly: true,
-    // `secure` segue o protocolo real da requisição, não o modo de build: na
-    // Vercel é sempre https, e em http — desenvolvimento, ou o build de
-    // produção rodando local — um cookie `secure` simplesmente não é enviado
-    // de volta, e a pessoa entra num laço de login que não termina.
-    secure: emHttps(cabecalhos.get("x-forwarded-proto")),
-    // `lax` deixa o link compartilhado funcionar e ainda barra POST de fora.
-    sameSite: "lax",
-    path: "/",
-    maxAge: Math.floor(DURACAO_DA_SESSAO_MS / 1000),
-  });
-
-  redirect(destino ?? "/");
-}
 
 export async function sair() {
   const jar = await cookies();

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,7 +5,6 @@ import { LightBlock } from "@/components/brand/light-block";
 import { QyraLogo } from "@/components/brand/logo";
 import { Button } from "@/components/ui/button";
 import { senhaConfigurada } from "@/server/auth/sessao";
-import { entrar } from "./actions";
 
 /**
  * Porta de entrada do painel.
@@ -23,6 +22,7 @@ const MENSAGENS: Record<string, string> = {
   senha: "Senha incorreta. Confira e tente de novo.",
   espera: "Tentativas demais. Espere alguns minutos antes de tentar outra vez.",
   config: "O painel ainda não tem senha configurada. Avise quem cuida do deploy.",
+  origem: "O envio não partiu desta página. Recarregue e tente de novo.",
 };
 
 export default async function LoginPage({
@@ -47,8 +47,25 @@ export default async function LoginPage({
             O desempenho de mídia da QYRA é restrito a quem tem a senha de acesso.
           </p>
 
-          <form action={entrar} className="mt-7 space-y-3">
+          {/* Envio nativo, e não Server Action: é a navegação do POST que faz o
+              gerenciador de senha do navegador oferecer guardar a senha — e
+              senha compartilhada precisa morar num gerenciador, não num
+              post-it. `method="post"` também mantém o formulário funcionando
+              se o JavaScript falhar. */}
+          <form method="post" action="/api/sessao" className="mt-7 space-y-3">
             <input type="hidden" name="de" value={de} />
+            {/* O Chrome só guarda a senha quando há um usuário para associar
+                a ela. Aqui a conta é uma só, então o campo é fixo e invisível:
+                dá ao gerenciador o par que ele espera sem inventar uma pergunta
+                para quem entra. */}
+            <input
+              type="text"
+              name="usuario"
+              value="qyra"
+              readOnly
+              hidden
+              autoComplete="username"
+            />
 
             <div className="space-y-1.5">
               <label htmlFor="senha" className="block font-medium text-plum-200 text-xs">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -42,6 +42,18 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // Sem senha configurada, `/api/health` responde mesmo assim.
+  //
+  // É a única situação em que o painel tranca tudo, e trancar junto o
+  // diagnóstico que explica o porquê deixa quem opera sem saída: a tela de
+  // login diz "falta configurar" e não há como descobrir o que falta. Aqui
+  // nenhum dado de negócio está acessível — os relatórios seguem barrados —,
+  // e a resposta lista apenas nomes de variável, nunca valores. Assim que a
+  // senha existir, esta porta se fecha junto com as outras.
+  if (!senhaConfigurada() && pathname === "/api/health") {
+    return NextResponse.next();
+  }
+
   if (await tokenValido(request.cookies.get(COOKIE_DA_SESSAO)?.value)) {
     return NextResponse.next();
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,6 +24,9 @@ import { COOKIE_DA_SESSAO, senhaConfigurada, tokenValido } from "@/server/auth/s
 function ehPublico(pathname: string): boolean {
   return (
     pathname === "/login" ||
+    // Onde o formulário de login posta. Sem isso o porteiro barraria a própria
+    // entrada, e o login viraria um laço.
+    pathname === "/api/sessao" ||
     pathname.startsWith("/_next/") ||
     pathname.startsWith("/brand/") ||
     pathname === "/favicon.ico" ||

--- a/tests/e2e/porta.spec.ts
+++ b/tests/e2e/porta.spec.ts
@@ -84,6 +84,38 @@ test("com senha configurada, o diagnóstico de saúde também fica atrás da por
   expect(resposta.status()).toBe(307);
 });
 
+test("o formulário é nativo, para o gerenciador de senha reconhecê-lo", async ({ page }) => {
+  await page.goto("/login");
+
+  const formulario = page.locator("form").filter({ has: page.locator("#senha") });
+
+  // Server Action envia por JavaScript, sem navegação, e o navegador não
+  // oferece guardar a senha. Envio nativo com POST devolve esse sinal.
+  await expect(formulario).toHaveAttribute("method", /post/i);
+  await expect(formulario).toHaveAttribute("action", "/api/sessao");
+
+  // O Chrome só guarda a senha quando há um usuário para associar a ela.
+  await expect(page.locator('input[autocomplete="username"]')).toHaveCount(1);
+  await expect(page.locator('input[autocomplete="current-password"]')).toHaveCount(1);
+});
+
+test("formulário postado de outro site não entra", async ({ request }) => {
+  const resposta = await request.post("/api/sessao", {
+    headers: {
+      origin: "https://site-de-fora.example",
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    form: { senha: SENHA_DE_TESTE },
+    maxRedirects: 0,
+  });
+
+  // A Server Action conferia a origem sozinha; a rota precisa conferir na mão.
+  // Sem isso, outra página postaria senhas em nome de quem tem a aba aberta.
+  expect(resposta.status()).toBe(303);
+  expect(resposta.headers().location).toMatch(/erro=origem/);
+  expect(resposta.headers()["set-cookie"]).toBeUndefined();
+});
+
 test("a tela de login não precisa de sessão para carregar", async ({ page }) => {
   const resposta = await page.goto("/login");
 

--- a/tests/e2e/porta.spec.ts
+++ b/tests/e2e/porta.spec.ts
@@ -74,6 +74,16 @@ test("um cookie forjado não abre a porta", async ({ page, context }) => {
   await expect(page).toHaveURL(/\/login/);
 });
 
+test("com senha configurada, o diagnóstico de saúde também fica atrás da porta", async ({
+  request,
+}) => {
+  // A exceção do `/api/health` vale só enquanto não há senha. Com senha — que
+  // é o caso desta suíte — ele volta para trás da porta como todo o resto.
+  const resposta = await request.get("/api/health", { maxRedirects: 0 });
+
+  expect(resposta.status()).toBe(307);
+});
+
 test("a tela de login não precisa de sessão para carregar", async ({ page }) => {
   const resposta = await page.goto("/login");
 


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — dois pedidos diretos: o painel travado sem dizer o que
faltava, e "coloca um salvar senha no Google, pra facilitar". Abro as Issues
correspondentes referenciando este PR.

---

## 1. Salvar a senha no navegador

Server Action envia por JavaScript, **sem navegação** — e é a navegação que o
Chrome usa como sinal de "alguém acabou de entrar em algum lugar". Por isso o
gerenciador nunca oferecia guardar a senha do painel, que é exatamente onde uma
senha compartilhada **deve** morar (é o que o estudo de segurança recomenda).

O formulário passa a postar de verdade, em `/api/sessao`, com resposta **303**
— que também impede o reenvio da senha ao recarregar a página. E ganha um campo
de usuário fixo e invisível: o Chrome só guarda a senha quando há um usuário
para associar a ela, e aqui a conta é uma só.

**A troca custa a proteção que o Next dava de graça** contra formulário postado
de outro site. Ela volta explícita, na conferência de origem, com um teste que
posta de fora e confirma que não entra — sem cookie e sem consumir o teto de
tentativas de um IP inocente.

## 2. O bug que apareceu no caminho

Este é o achado que importa. O redirect era montado com
`new URL(caminho, request.url)`, e **`request.url` não é o endereço que o
navegador pediu**: pedindo `127.0.0.1`, o destino saía como `localhost`.

Origem diferente → a CSP `form-action 'self'` recusa o envio → **o login fica
parado sem nenhuma explicação na tela.** Nenhum erro, nenhuma mensagem, só o
botão que não faz nada.

**Na Vercel seria pior:** `request.url` traz a URL interna do deploy, não
`dashboard.qyra.com.br`. Quem entrasse seria jogado para fora do domínio, ou
barrado do mesmo jeito.

`Location` relativo resolve na raiz: o navegador resolve contra o endereço que
ele mesmo pediu, e o destino é a mesma origem por construção.

Levei um tempo para achar porque a suíte reprovava contra um **servidor
fantasma** de uma execução anterior — o Next renomeia o processo, e ele não
aparecia num `ps` procurando por `next start`. O `reuseExistingServer` do
Playwright reaproveitava o build velho. Vale como lembrete: teste que falha
sem explicação merece desconfiança do ambiente, não só do código.

## 3. Saída para quem tranca o painel sem querer

Sem `QYRA_SENHA`, o painel trancava tudo — **inclusive o diagnóstico que
explicaria o que falta**. A tela dizia "falta configurar" e não havia como
descobrir o quê: a variável mais importante do projeto era a única que não
constava no `/api/health`.

- `QYRA_SENHA`, `QYRA_SESSAO_SECRET` e as duas do Kommo entram na lista de
  variáveis reportadas — só a presença, nunca o valor
- `/api/health` passa pela porta **enquanto não houver senha configurada**.
  Nesse estado nenhum dado de negócio está acessível: os relatórios seguem
  barrados e a resposta lista apenas nomes de variável. Assim que a senha
  existir, essa porta fecha junto com as outras, e um teste do e2e afirma isso

## Como foi validado

- [x] `npm run verify` — **231 testes**, lint, tipos e contrato de arquitetura
- [x] `npm run test:e2e` — **46/46** (3 novos)
- [x] `npm run build` limpo
- [x] Conferido em navegador real: login por formulário nativo, `Location`
      relativo na resposta, e nenhum bloqueio de CSP

Testes novos: o formulário é nativo e traz os dois campos que o gerenciador
espera; POST de outra origem não entra; e o diagnóstico volta para trás da
porta quando há senha.

## Riscos e limitações

**Chrome decide sozinho quando oferecer.** As condições agora estão todas
atendidas — formulário nativo, navegação, `autocomplete` nos dois campos —, mas
o navegador ainda pode não oferecer em janela anônima ou com o gerenciador
desligado.

**A conferência de origem recusa requisição sem `origin` nem `referer`.**
Navegador sempre manda um dos dois num envio de formulário; cliente HTTP feito
à mão, não. É deliberado, e significa que `/api/sessao` não serve para
automação externa.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_