### PR TITLE
fix: venda conta no período em que fechou, e só no funil de vendas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,8 @@ KOMMO_SUBDOMAIN=
 # Integrações > sua integração > Chaves e escopos). Sem ela a tela de Vendas
 # roda em demonstração. Ver docs/integracoes.md.
 KOMMO_ACCESS_TOKEN=
+
+# Opcional: o funil de vendas, quando a conta tem mais de um. `142` é etapa de
+# ganho em todo funil do Kommo, então sem isto um pipeline de suporte entraria
+# no faturamento. O id aparece na URL do funil.
+KOMMO_PIPELINE_ID=

--- a/docs/integracoes.md
+++ b/docs/integracoes.md
@@ -211,6 +211,7 @@ Kommo diz quanto daquilo virou dinheiro.
 |---|---|
 | `KOMMO_SUBDOMAIN` | `marketingqyracombr` — o nome na URL da conta. Não é segredo |
 | `KOMMO_ACCESS_TOKEN` | Chave de longa duração da integração privada. **É segredo** |
+| `KOMMO_PIPELINE_ID` | Opcional. O funil de vendas, quando a conta tem mais de um — o do Kommo aparece na URL do funil |
 
 ### Passo a passo
 
@@ -266,6 +267,29 @@ que não passa por URL com parâmetro e portanto não carrega UTM naturalmente.
 Ligar venda a campanha nesses casos exige uma automação capturando a origem da
 conversa e gravando no negócio — é o ponto em que uma ferramenta como o n8n
 tem função de verdade.
+
+### Quando uma venda conta
+
+**Pela data de fechamento.** "Vendemos 17 em agosto" significa 17 negócios que
+foram marcados como ganhos em agosto — não 17 que entraram em agosto e
+fecharam algum dia. É a conta que a operação usa, e é a que faz o total dos
+indicadores bater com a soma das barras do gráfico.
+
+Por isso o conector faz **duas consultas**: uma por data de criação, que
+responde "quantos negócios entraram e onde estão agora", e outra por data de
+fechamento, que responde "quanto vendemos".
+
+A taxa de conversão é a exceção, e de propósito: ela olha só os **criados** no
+período e pergunta quantos daquela safra já viraram venda. Cruzar "fechados no
+mês" com "criados no mês" produziria uma taxa que pode passar de 100% quando o
+ciclo é longo.
+
+### Mais de um funil
+
+`142` é a etapa de ganho em **todo** funil do Kommo. Numa conta com pipeline de
+suporte ou pós-venda, negócios ganhos ali entrariam no faturamento sem ninguém
+notar. `KOMMO_PIPELINE_ID` restringe ao funil de vendas; sem ele, a conta
+inteira é somada.
 
 ### Leads de entrada
 

--- a/src/server/connectors/kommo.ts
+++ b/src/server/connectors/kommo.ts
@@ -106,18 +106,31 @@ function campo(lead: LeadDoKommo, nomes: string[]): string | null {
  * O Kommo responde **204 sem corpo** quando não há nada na página — que o
  * `httpJson` entrega como objeto vazio, e o laço encerra sozinho.
  */
-async function buscarLeads(range: DateRange): Promise<LeadDoKommo[]> {
+function inicioDoDia(dia: string): number {
+  return Date.parse(`${dia}T00:00:00Z`) / 1000;
+}
+
+function fimDoDia(dia: string): number {
+  return Date.parse(`${dia}T23:59:59Z`) / 1000;
+}
+
+/**
+ * Negócios de uma janela, filtrados por criação ou por fechamento.
+ *
+ * As duas perguntas do relatório precisam de conjuntos diferentes: "quantos
+ * negócios entraram" olha a criação, "quanto vendemos" olha o fechamento. Um
+ * negócio criado em julho e fechado em agosto pertence ao agosto do segundo, e
+ * ao julho do primeiro.
+ */
+async function buscarLeads(range: DateRange, campoDeData: "created_at" | "closed_at") {
   const url = new URL(`${baseDaApi()}/leads`);
-  // Fechamento pode cair fora da janela em que o lead nasceu, então o filtro é
-  // por criação e o corte por data de fechamento acontece depois, em memória.
-  url.searchParams.set(
-    "filter[created_at][from]",
-    String(Date.parse(`${range.from}T00:00:00Z`) / 1000),
-  );
-  url.searchParams.set(
-    "filter[created_at][to]",
-    String(Date.parse(`${range.to}T23:59:59Z`) / 1000),
-  );
+  url.searchParams.set(`filter[${campoDeData}][from]`, String(inicioDoDia(range.from)));
+  url.searchParams.set(`filter[${campoDeData}][to]`, String(fimDoDia(range.to)));
+  const funil = getEnv().KOMMO_PIPELINE_ID;
+  // Sem funil configurado, conta a conta inteira. Com ele, só o funil de
+  // vendas — `142` é etapa de ganho em **todo** funil, e um pipeline de
+  // suporte com etapa de ganho entraria no faturamento sem ninguém notar.
+  if (funil) url.searchParams.set("filter[pipeline_id]", funil);
   url.searchParams.set("limit", String(POR_PAGINA));
 
   const todos: LeadDoKommo[] = [];
@@ -132,7 +145,15 @@ async function buscarLeads(range: DateRange): Promise<LeadDoKommo[]> {
     proxima = leads.length === POR_PAGINA ? (resposta._links?.next?.href ?? null) : null;
   }
 
-  return todos;
+  // Confere a janela de novo em memória. Filtro que a API não reconheça é
+  // ignorado em silêncio, e "ignorado em silêncio" num relatório de vendas
+  // significa somar negócio de outro período sem ninguém perceber.
+  const de = inicioDoDia(range.from);
+  const ate = fimDoDia(range.to);
+  return todos.filter((lead) => {
+    const quando = lead[campoDeData];
+    return typeof quando === "number" && quando >= de && quando <= ate;
+  });
 }
 
 /**
@@ -224,28 +245,36 @@ function montarFunil(
  * Só existe se o Kommo estiver recebendo a UTM no negócio. Quando não estiver,
  * a tabela sai vazia em vez de inventar origem, e o aviso diz o que configurar.
  */
-function montarOrigens(leads: LeadDoKommo[]): TableBlock {
+function montarOrigens(criados: LeadDoKommo[], ganhos: LeadDoKommo[]): TableBlock {
   const porOrigem = new Map<string, { leads: number; vendas: number; receita: number }>();
 
-  for (const lead of leads) {
-    const origem =
-      campo(lead, ["utm_source", "utm source", "origem"]) ??
-      (lead.custom_fields_values ? "Sem UTM" : "Sem UTM");
+  const chaveDaOrigem = (lead: LeadDoKommo): string => {
+    const origem = campo(lead, ["utm_source", "utm source", "origem"]) ?? "Sem UTM";
     const campanha = campo(lead, ["utm_campaign", "utm campaign", "campanha"]);
-    const chave = campanha ? `${origem} · ${campanha}` : origem;
+    return campanha ? `${origem} · ${campanha}` : origem;
+  };
 
+  const linha = (chave: string) => {
     const atual = porOrigem.get(chave) ?? { leads: 0, vendas: 0, receita: 0 };
-    atual.leads += 1;
-    if (lead.status_id === GANHO) {
-      atual.vendas += 1;
-      atual.receita += lead.price ?? 0;
-    }
     porOrigem.set(chave, atual);
+    return atual;
+  };
+
+  // Negócios contam por criação, vendas por fechamento — a mesma separação do
+  // resto da tela. Por isso a coluna de conversão aqui é aproximada quando o
+  // ciclo é longo, e a descrição diz isso.
+  for (const lead of criados) linha(chaveDaOrigem(lead)).leads += 1;
+
+  for (const lead of ganhos) {
+    const atual = linha(chaveDaOrigem(lead));
+    atual.vendas += 1;
+    atual.receita += lead.price ?? 0;
   }
 
   return {
     title: "Vendas por origem",
-    description: "De onde vieram os negócios que fecharam, pela UTM registrada no Kommo.",
+    description:
+      "De onde vieram os negócios, pela UTM registrada no Kommo. Negócios contam por criação e vendas por fechamento, então a conversão é aproximada quando o ciclo passa do período.",
     columns: [
       { key: "origem", label: "Origem", align: "left" },
       { key: "leads", label: "Negócios", format: "integer", align: "right" },
@@ -281,15 +310,26 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
   }
 
   try {
-    const [leads, etapas, deEntrada] = await Promise.all([
-      buscarLeads(range),
+    // Dois conjuntos, duas perguntas. `criados` responde "quantos negócios
+    // entraram e onde estão agora"; `fechados` responde "quanto vendemos".
+    // Antes o indicador contava criado-e-ganho e o gráfico creditava no dia do
+    // fechamento — bases diferentes na mesma tela, e os dois números não
+    // batiam.
+    const [criados, fechados, etapas, deEntrada] = await Promise.all([
+      buscarLeads(range, "created_at"),
+      buscarLeads(range, "closed_at"),
       buscarEtapas(),
       contarLeadsDeEntrada(),
     ]);
 
-    const ganhos = leads.filter((l) => l.status_id === GANHO);
+    const leads = criados;
+    const ganhos = fechados.filter((l) => l.status_id === GANHO);
     const receita = ganhos.reduce((acc, l) => acc + (l.price ?? 0), 0);
-    const emAberto = leads.filter((l) => l.status_id !== GANHO && l.status_id !== PERDIDO);
+    const emAberto = criados.filter((l) => l.status_id !== GANHO && l.status_id !== PERDIDO);
+    // Cortada entre os criados, não entre os fechados: é a fatia daquela safra
+    // que já virou venda. Misturar "fechados no mês" com "criados no mês"
+    // produziria uma taxa que pode passar de 100%.
+    const ganhosDaSafra = criados.filter((l) => l.status_id === GANHO).length;
 
     // Ciclo médio só considera quem fechou e tem as duas pontas: sem
     // `closed_at`, incluir o negócio arrastaria a média para baixo.
@@ -299,23 +339,22 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
     const cicloMedio = ciclos.length === 0 ? 0 : ciclos.reduce((a, b) => a + b, 0) / ciclos.length;
 
     const porDia = new Map<string, { vendas: number; receita: number; leads: number }>();
-    for (const lead of leads) {
-      const criado = paraDia(lead.created_at);
-      if (criado) {
-        const atual = porDia.get(criado) ?? { vendas: 0, receita: 0, leads: 0 };
-        atual.leads += 1;
-        porDia.set(criado, atual);
-      }
-      // A venda conta no dia em que fechou, não no dia em que o lead nasceu —
-      // é a diferença entre "quanto entrou" e "quanto vendemos" no dia.
-      if (lead.status_id === GANHO) {
-        const fechado = paraDia(lead.closed_at) ?? criado;
-        if (!fechado) continue;
-        const atual = porDia.get(fechado) ?? { vendas: 0, receita: 0, leads: 0 };
-        atual.vendas += 1;
-        atual.receita += lead.price ?? 0;
-        porDia.set(fechado, atual);
-      }
+    for (const lead of criados) {
+      const dia = paraDia(lead.created_at);
+      if (!dia) continue;
+      const atual = porDia.get(dia) ?? { vendas: 0, receita: 0, leads: 0 };
+      atual.leads += 1;
+      porDia.set(dia, atual);
+    }
+    // A venda conta no dia em que fechou — mesma base do indicador acima, para
+    // a soma das barras bater com o total.
+    for (const lead of ganhos) {
+      const dia = paraDia(lead.closed_at);
+      if (!dia) continue;
+      const atual = porDia.get(dia) ?? { vendas: 0, receita: 0, leads: 0 };
+      atual.vendas += 1;
+      atual.receita += lead.price ?? 0;
+      porDia.set(dia, atual);
     }
 
     const series: SeriesPoint[] = eachDay(range).map((date) => {
@@ -377,9 +416,9 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
         {
           key: "conversao",
           label: "Lead vira venda",
-          value: leads.length === 0 ? 0 : ganhos.length / leads.length,
+          value: criados.length === 0 ? 0 : ganhosDaSafra / criados.length,
           format: "percent",
-          hint: "Negócios ganhos sobre todos os negócios criados no período.",
+          hint: "Dos negócios criados no período, quantos já viraram venda. Conta a mesma safra dos dois lados, então não se compara com as vendas fechadas acima.",
         },
         {
           key: "ciclo",
@@ -396,7 +435,7 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
         { key: "receita", label: "Receita", format: "currency", slot: 5 },
         { key: "vendas", label: "Vendas", format: "integer", slot: 2 },
       ],
-      tables: [montarFunil(leads, etapas, deEntrada), montarOrigens(leads)],
+      tables: [montarFunil(criados, etapas, deEntrada), montarOrigens(criados, ganhos)],
       notices: avisos,
     };
   } catch (erro) {

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -96,6 +96,13 @@ const schema = z.object({
   KOMMO_SUBDOMAIN: optionalString,
   /** Chave de longa duração da integração privada. */
   KOMMO_ACCESS_TOKEN: optionalString,
+  /**
+   * Funil de vendas, quando a conta tem mais de um.
+   *
+   * `142` é etapa de ganho em todo funil do Kommo: sem restringir, um pipeline
+   * de suporte ou de pós-venda entra no faturamento junto.
+   */
+  KOMMO_PIPELINE_ID: optionalString,
 
   /** Janela e teto do rate limit das rotas de API. */
   RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000),

--- a/tests/integration/kommo.test.ts
+++ b/tests/integration/kommo.test.ts
@@ -28,6 +28,13 @@ interface LeadFalso {
   custom_fields_values?: Array<{ field_name?: string; values?: Array<{ value?: string }> }>;
 }
 
+/**
+ * Dublê da API, respeitando o filtro pedido.
+ *
+ * O conector faz duas consultas — uma por criação, outra por fechamento — e
+ * devolver o mesmo conjunto para as duas esconderia justamente o que separa
+ * "quantos entraram" de "quanto vendemos".
+ */
 function kommo(leads: LeadFalso[], etapas: Array<{ id: number; name: string }> = []) {
   return vi.fn(async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input.toString();
@@ -39,7 +46,19 @@ function kommo(leads: LeadFalso[], etapas: Array<{ id: number; name: string }> =
       );
     }
 
-    return new Response(JSON.stringify({ _embedded: { leads } }), {
+    const endereco = new URL(url);
+    const campo = endereco.searchParams.has("filter[closed_at][from]") ? "closed_at" : "created_at";
+    const de = Number(endereco.searchParams.get(`filter[${campo}][from]`) ?? 0);
+    const ate = Number(
+      endereco.searchParams.get(`filter[${campo}][to]`) ?? Number.MAX_SAFE_INTEGER,
+    );
+
+    const recorte = leads.filter((lead) => {
+      const quando = lead[campo];
+      return typeof quando === "number" && quando >= de && quando <= ate;
+    });
+
+    return new Response(JSON.stringify({ _embedded: { leads: recorte } }), {
       status: 200,
       headers: { "content-type": "application/json" },
     });
@@ -73,8 +92,20 @@ afterEach(() => {
 describe("vendas pelo Kommo", () => {
   it("só conta como receita o negócio ganho", async () => {
     const { report } = await relatorio([
-      { id: 1, price: 1000, status_id: GANHO, created_at: emSegundos("2026-02-03T10:00:00Z") },
-      { id: 2, price: 5000, status_id: PERDIDO, created_at: emSegundos("2026-02-04T10:00:00Z") },
+      {
+        id: 1,
+        price: 1000,
+        status_id: GANHO,
+        created_at: emSegundos("2026-02-03T10:00:00Z"),
+        closed_at: emSegundos("2026-02-05T10:00:00Z"),
+      },
+      {
+        id: 2,
+        price: 5000,
+        status_id: PERDIDO,
+        created_at: emSegundos("2026-02-04T10:00:00Z"),
+        closed_at: emSegundos("2026-02-06T10:00:00Z"),
+      },
       { id: 3, price: 9000, status_id: 20, created_at: emSegundos("2026-02-05T10:00:00Z") },
     ]);
 
@@ -88,7 +119,13 @@ describe("vendas pelo Kommo", () => {
 
   it("a taxa de conversão usa todos os negócios como base", async () => {
     const { report } = await relatorio([
-      { id: 1, price: 100, status_id: GANHO, created_at: emSegundos("2026-02-03T10:00:00Z") },
+      {
+        id: 1,
+        price: 100,
+        status_id: GANHO,
+        created_at: emSegundos("2026-02-03T10:00:00Z"),
+        closed_at: emSegundos("2026-02-04T10:00:00Z"),
+      },
       { id: 2, status_id: PERDIDO, created_at: emSegundos("2026-02-03T10:00:00Z") },
       { id: 3, status_id: 20, created_at: emSegundos("2026-02-03T10:00:00Z") },
       { id: 4, status_id: 20, created_at: emSegundos("2026-02-03T10:00:00Z") },
@@ -119,6 +156,63 @@ describe("vendas pelo Kommo", () => {
     expect(fechamento?.vendas).toBe(1);
   });
 
+  it("conta a venda no período em que ela fechou, não no que o lead entrou", async () => {
+    const { report } = await relatorio([
+      // Entrou antes do período e fechou dentro dele: é venda deste mês.
+      {
+        id: 1,
+        price: 4000,
+        status_id: GANHO,
+        created_at: emSegundos("2026-01-10T10:00:00Z"),
+        closed_at: emSegundos("2026-02-14T10:00:00Z"),
+      },
+      // Entrou dentro do período e ainda não fechou: não é venda de mês nenhum.
+      { id: 2, status_id: 20, created_at: emSegundos("2026-02-15T10:00:00Z") },
+    ]);
+
+    expect(kpi(report, "vendas")).toBe(1);
+    expect(kpi(report, "receita")).toBe(4000);
+    expect(kpi(report, "emAberto")).toBe(1);
+  });
+
+  it("o total dos indicadores bate com a soma das barras", async () => {
+    const { report } = await relatorio([
+      {
+        id: 1,
+        price: 1500,
+        status_id: GANHO,
+        created_at: emSegundos("2026-01-20T10:00:00Z"),
+        closed_at: emSegundos("2026-02-03T10:00:00Z"),
+      },
+      {
+        id: 2,
+        price: 2500,
+        status_id: GANHO,
+        created_at: emSegundos("2026-02-01T10:00:00Z"),
+        closed_at: emSegundos("2026-02-20T10:00:00Z"),
+      },
+    ]);
+
+    // A regressão que motivou o teste: o indicador contava criado-e-ganho, o
+    // gráfico creditava no fechamento, e os dois números discordavam na tela.
+    const somaDasBarras = report.series.reduce((acc, p) => acc + Number(p.receita), 0);
+    const vendasNasBarras = report.series.reduce((acc, p) => acc + Number(p.vendas), 0);
+
+    expect(somaDasBarras).toBe(kpi(report, "receita"));
+    expect(vendasNasBarras).toBe(kpi(report, "vendas"));
+  });
+
+  it("restringe ao funil de vendas quando configurado", async () => {
+    vi.stubEnv("KOMMO_PIPELINE_ID", "14120879");
+    vi.resetModules();
+    const { chamadas } = await relatorio([]);
+
+    const urls = chamadas.mock.calls.map(([e]) => (typeof e === "string" ? e : String(e)));
+    // `142` é etapa de ganho em todo funil: sem restringir, um pipeline de
+    // suporte entraria no faturamento.
+    expect(urls.some((u) => u.includes("filter%5Bpipeline_id%5D=14120879"))).toBe(true);
+  });
+
   it("o ciclo médio ignora quem não fechou", async () => {
     const { report } = await relatorio([
       {
@@ -147,6 +241,7 @@ describe("vendas pelo Kommo", () => {
         price: 3000,
         status_id: GANHO,
         created_at: emSegundos("2026-02-03T10:00:00Z"),
+        closed_at: emSegundos("2026-02-05T10:00:00Z"),
         custom_fields_values: utm("meta", "emagrecimento"),
       },
       {
@@ -160,6 +255,7 @@ describe("vendas pelo Kommo", () => {
         price: 1000,
         status_id: GANHO,
         created_at: emSegundos("2026-02-03T10:00:00Z"),
+        closed_at: emSegundos("2026-02-05T10:00:00Z"),
         custom_fields_values: utm("google", "marca"),
       },
     ]);
@@ -175,7 +271,13 @@ describe("vendas pelo Kommo", () => {
 
   it("sem UTM nenhuma, avisa em vez de inventar origem", async () => {
     const { report } = await relatorio([
-      { id: 1, price: 100, status_id: GANHO, created_at: emSegundos("2026-02-03T10:00:00Z") },
+      {
+        id: 1,
+        price: 100,
+        status_id: GANHO,
+        created_at: emSegundos("2026-02-03T10:00:00Z"),
+        closed_at: emSegundos("2026-02-04T10:00:00Z"),
+      },
     ]);
 
     // O aviso é de operação: quem abre o painel não precisa vê-lo, quem
@@ -188,8 +290,18 @@ describe("vendas pelo Kommo", () => {
     const { report } = await relatorio([
       // É o estado real da conta: negócio movido para ganho, campo de valor
       // nunca preenchido.
-      { id: 1, status_id: GANHO, created_at: emSegundos("2026-02-03T10:00:00Z") },
-      { id: 2, status_id: GANHO, created_at: emSegundos("2026-02-04T10:00:00Z") },
+      {
+        id: 1,
+        status_id: GANHO,
+        created_at: emSegundos("2026-02-03T10:00:00Z"),
+        closed_at: emSegundos("2026-02-05T10:00:00Z"),
+      },
+      {
+        id: 2,
+        status_id: GANHO,
+        created_at: emSegundos("2026-02-04T10:00:00Z"),
+        closed_at: emSegundos("2026-02-06T10:00:00Z"),
+      },
     ]);
 
     expect(kpi(report, "vendas")).toBe(2);
@@ -201,7 +313,13 @@ describe("vendas pelo Kommo", () => {
 
   it("não inventa aviso de valor quando a receita existe", async () => {
     const { report } = await relatorio([
-      { id: 1, price: 500, status_id: GANHO, created_at: emSegundos("2026-02-03T10:00:00Z") },
+      {
+        id: 1,
+        price: 500,
+        status_id: GANHO,
+        created_at: emSegundos("2026-02-03T10:00:00Z"),
+        closed_at: emSegundos("2026-02-04T10:00:00Z"),
+      },
     ]);
 
     expect(report.kpis.find((k) => k.key === "receita")?.hint).toBeUndefined();


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — a tela de Vendas conectou ao Kommo real e mostrou **17
vendas ganhas**, com a pergunta "de onde tirou isso?". Investigar respondeu a
pergunta e revelou dois defeitos. Abro a Issue de Correção referenciando este
PR.

## O defeito principal

Os **indicadores** contavam negócio criado no período que estivesse ganho. O
**gráfico** creditava a venda no dia do fechamento.

Bases diferentes na mesma tela: o total de cima não batia com a soma das
barras, e — pior — **nenhum dos dois respondia "quanto vendemos este mês"**.

Um negócio criado em janeiro e fechado em fevereiro não aparecia como venda de
mês nenhum nos indicadores.

## A regra agora

| Pergunta | Base |
|---|---|
| Quanto vendemos | Negócios **fechados** no período |
| Quantos negócios entraram, e onde estão | Negócios **criados** no período |

Duas consultas, com papéis separados. Negócio de janeiro fechado em fevereiro é
**venda de fevereiro** e aparece no **funil de janeiro** — as duas coisas ao
mesmo tempo, cada uma respondendo a sua pergunta.

**A taxa de conversão fica fora dessa regra, de propósito.** Ela olha só a safra
criada no período e pergunta quantos daquela safra já viraram venda. Cruzar
"fechados no mês" com "criados no mês" daria taxa acima de 100% sempre que o
ciclo passasse do período. A dica no indicador diz isso.

## O segundo defeito: `142` é ganho em todo funil

O identificador de "venda ganha" do Kommo é o mesmo em **qualquer** pipeline.
Numa conta com funil de suporte ou pós-venda, negócios ganhos ali entravam no
faturamento sem ninguém notar — e é uma explicação plausível para um número
maior que o esperado.

`KOMMO_PIPELINE_ID` (opcional) restringe ao funil de vendas. Sem ele, o
comportamento anterior continua — nenhuma conta quebra por não ter configurado.

## Um cuidado a mais

A janela é conferida **em memória** depois da resposta. Filtro que a API não
reconheça é ignorado em silêncio, e silêncio num relatório de vendas significa
somar negócio de outro período sem aparecer na tela.

## Como foi validado

- [x] `npm run verify` — **234 testes** (3 novos), lint, tipos e contrato de arquitetura
- [x] `npm run test:e2e` — 46/46
- [x] `npm run build` limpo

Testes novos, cada um travando um defeito real:

- negócio criado antes e fechado dentro do período **é** venda do período;
  criado dentro e ainda aberto **não é** venda de nenhum;
- **a soma das barras bate com o total dos indicadores** — a regressão exata
  que motivou o PR;
- o filtro de funil sai na URL quando configurado.

O dublê da API foi refeito para respeitar o filtro pedido: devolver o mesmo
conjunto para as duas consultas esconderia justamente o que as separa.

## Riscos e limitações

**O número na tela vai mudar.** É o objetivo — o anterior respondia a uma
pergunta que ninguém faz.

**Uma consulta a mais por carregamento.** A cota do Kommo (~7 req/s) comporta
com folga.

**`KOMMO_PIPELINE_ID` ainda não está configurado.** Enquanto não estiver, ganhos
de outros funis continuam somando. O id do funil de vendas aparece na URL do
funil no Kommo.

**Negócio ganho sem `closed_at`** não entra na contagem. O Kommo preenche o
campo ao mover para ganho; registro importado de fora pode não ter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_