### PR TITLE
fix: KOMMO_PIPELINE_ID passa a aparecer no diagnóstico

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -43,6 +43,10 @@ const CONFIGURAVEIS = [
   "QYRA_SESSAO_SECRET",
   "KOMMO_SUBDOMAIN",
   "KOMMO_ACCESS_TOKEN",
+  // Entrou depois das outras duas e ficou de fora da lista — a mesma armadilha
+  // de antes: variável que ninguém consegue conferir se pegou. Opcional, então
+  // aparecer em "ausentes" é resultado legítimo.
+  "KOMMO_PIPELINE_ID",
 ] as const;
 
 /**


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — apareceu ao ler o `/api/health` de produção para investigar
um número de vendas que não fechava. Abro a Issue de Correção referenciando
este PR.

## O que estava errado

`KOMMO_PIPELINE_ID` entrou no projeto depois das outras duas variáveis do
Kommo e ficou **fora da lista** do `/api/health` — nem em `variaveisPresentes`,
nem em `variaveisAusentes`. Simplesmente invisível.

É **a mesma armadilha corrigida dias atrás com `QYRA_SENHA`**: quem cadastra a
variável não tem como confirmar que ela pegou, e fica sem saber se o funil está
mesmo restrito. No caso concreto, impedia responder "os ganhos de outros funis
já saíram da conta?".

Sendo opcional, aparecer em `variaveisAusentes` é resultado legítimo — a lista
já separa "não existe" de "existe em branco".

## Como foi validado

- [x] `npm run verify` — 234 testes, lint, tipos e contrato de arquitetura

## Riscos e limitações

**Só a presença, nunca o valor** — mesma regra das demais. O id de funil não é
segredo, mas a lista não abre exceção para não virar precedente.

**A lista é manual**, e foi ela que falhou duas vezes agora. Vale, num próximo
passo, derivá-la do próprio esquema de ambiente em vez de manter à mão — assim
variável nova nasce visível.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_