### PR TITLE
fix: a tela de Vendas para de mentir quando não houve venda, e o funil volta a ser funil

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,6 +47,15 @@ export interface Kpi {
   /** `true` quando cair é bom (CPA, CPC, CPL). Inverte a leitura do delta. */
   lowerIsBetter?: boolean;
   hint?: string;
+  /**
+   * Não compare este número com o período anterior.
+   *
+   * Para métrica derivada — ticket médio, ciclo, taxa —, zero não quer dizer
+   * "caiu para zero", quer dizer "não houve o que medir". Comparar produz
+   * "-100%" com seta, e num ciclo de fechamento a seta sai **verde**, como se
+   * fechar nada fosse melhora.
+   */
+  semComparacao?: boolean;
 }
 
 /** Um ponto diário da série. `date` é ISO; o resto são métricas numéricas. */

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -814,23 +814,26 @@ export function mockVendas(range: DateRange, fetchedAt = NOW): ChannelReport {
     tables: [
       {
         title: "Negócios por etapa",
-        description: "Onde os negócios do período estão parados, e quanto há em cada etapa.",
+        description:
+          "Onde os negócios do período estão parados. Na ordem do funil, com as etapas vazias à vista — etapa sem ninguém é o gargalo.",
         columns: [
           { key: "etapa", label: "Etapa", align: "left" },
           { key: "negocios", label: "Negócios", format: "integer", align: "right" },
           { key: "valor", label: "Valor", format: "currency", align: "right" },
         ],
-        // As etapas saem dos mesmos totais dos indicadores. Inventar fatias
-        // soltas produzia um funil que contradizia o topo da tela — e num
-        // painel de demonstração isso lê como erro de cálculo, não como dado
-        // fictício.
+        // As etapas saem dos mesmos totais dos indicadores, e na ordem do
+        // funil — não por volume. Inventar fatias soltas produzia um funil que
+        // contradizia o topo da tela, e num painel de demonstração isso lê
+        // como erro de cálculo, não como dado fictício.
         rows: (() => {
           const perdidos = Math.round((leads - vendas) * 0.34);
           const abertos = leads - vendas - perdidos;
+          const primeiro = Math.round(abertos * 0.52);
+          const avaliacao = Math.round(abertos * 0.31);
           return [
-            ["Primeiro contato", Math.round(abertos * 0.52)],
-            ["Avaliação agendada", Math.round(abertos * 0.31)],
-            ["Proposta enviada", abertos - Math.round(abertos * 0.52) - Math.round(abertos * 0.31)],
+            ["Primeiro contato", primeiro],
+            ["Avaliação agendada", avaliacao],
+            ["Proposta enviada", abertos - primeiro - avaliacao],
             ["Venda ganha", vendas],
             ["Perdido", perdidos],
           ].map(([etapa, negocios]) => ({

--- a/src/server/connectors/kommo.ts
+++ b/src/server/connectors/kommo.ts
@@ -167,13 +167,22 @@ async function buscarLeads(range: DateRange, campoDeData: "created_at" | "closed
  * negócio comum, e adivinhar a forma para extrair valor renderia um total
  * inventado.
  */
-async function contarLeadsDeEntrada(): Promise<number> {
+async function contarLeadsDeEntrada(range: DateRange): Promise<number> {
   try {
-    const resposta = await httpJson<{ _embedded?: { unsorted?: unknown[] } }>(
+    const resposta = await httpJson<{ _embedded?: { unsorted?: Array<{ created_at?: number }> } }>(
       `${baseDaApi()}/leads/unsorted?limit=${POR_PAGINA}`,
       { headers: autorizacao() },
     );
-    return resposta._embedded?.unsorted?.length ?? 0;
+
+    // Recortado pelo período, como todas as outras linhas da tabela. Sem isso
+    // a fila inteira entrava numa tabela que promete "os negócios do período",
+    // e o total não fechava com nada.
+    const de = inicioDoDia(range.from);
+    const ate = fimDoDia(range.to);
+    return (resposta._embedded?.unsorted ?? []).filter(
+      (item) =>
+        typeof item.created_at === "number" && item.created_at >= de && item.created_at <= ate,
+    ).length;
   } catch {
     // A área pode estar vazia (204) ou o escopo não cobrir: some da tabela.
     return 0;
@@ -319,7 +328,7 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
       buscarLeads(range, "created_at"),
       buscarLeads(range, "closed_at"),
       buscarEtapas(),
-      contarLeadsDeEntrada(),
+      contarLeadsDeEntrada(range),
     ]);
 
     const leads = criados;
@@ -412,12 +421,14 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
           label: "Ticket médio",
           value: ganhos.length === 0 ? 0 : receita / ganhos.length,
           format: "currency",
+          semComparacao: ganhos.length === 0,
         },
         {
           key: "conversao",
           label: "Lead vira venda",
           value: criados.length === 0 ? 0 : ganhosDaSafra / criados.length,
           format: "percent",
+          semComparacao: criados.length === 0,
           hint: "Dos negócios criados no período, quantos já viraram venda. Conta a mesma safra dos dois lados, então não se compara com as vendas fechadas acima.",
         },
         {
@@ -426,6 +437,9 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
           value: cicloMedio,
           format: "decimal",
           lowerIsBetter: true,
+          // Sem fechamento no período não há ciclo. Comparar pintaria de verde
+          // um "-100%" que significa "nada fechou".
+          semComparacao: ciclos.length === 0,
           hint: "Dias entre a criação do negócio e o fechamento, na média dos que fecharam.",
         },
         { key: "emAberto", label: "Em aberto", value: emAberto.length, format: "integer" },

--- a/src/server/connectors/kommo.ts
+++ b/src/server/connectors/kommo.ts
@@ -189,29 +189,45 @@ async function contarLeadsDeEntrada(range: DateRange): Promise<number> {
   }
 }
 
-/** Nome de cada etapa, por id. Sem isso o funil sairia como números. */
-async function buscarEtapas(): Promise<Map<number, string>> {
-  const nomes = new Map<number, string>();
+interface EtapaDoFunil {
+  id: number;
+  nome: string;
+}
+
+/**
+ * As etapas do funil, **na ordem do funil e todas elas**.
+ *
+ * Não é só para trocar número por nome. É o esqueleto da tabela: sem ele, só
+ * apareciam as etapas que tinham negócio no período, e etapa vazia sumia da
+ * tela. Só que "ninguém chega em Negociação" é exatamente o que um funil
+ * precisa mostrar — some a etapa, some o gargalo.
+ *
+ * A ordem vem do `sort` do Kommo, a mesma das colunas lá. Ordenar por volume
+ * transformaria o funil numa lista de campeões, que não é o que ele é.
+ */
+async function buscarEtapas(): Promise<EtapaDoFunil[]> {
   try {
     const resposta = await httpJson<RespostaDeFunis>(`${baseDaApi()}/leads/pipelines`, {
       headers: autorizacao(),
     });
-    for (const funil of resposta._embedded?.pipelines ?? []) {
-      for (const etapa of funil._embedded?.statuses ?? []) {
-        if (etapa.name) nomes.set(etapa.id, etapa.name);
-      }
-    }
+
+    const escolhido = getEnv().KOMMO_PIPELINE_ID;
+    const funis = (resposta._embedded?.pipelines ?? []).filter(
+      (funil) => !escolhido || String(funil.id) === escolhido,
+    );
+
+    return funis
+      .flatMap((funil) => funil._embedded?.statuses ?? [])
+      .filter((etapa) => Boolean(etapa.name))
+      .sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0))
+      .map((etapa) => ({ id: etapa.id, nome: etapa.name as string }));
   } catch {
-    // Enfeite: sem os nomes o funil ainda soma, só fica menos legível.
+    // Sem o esqueleto o funil ainda soma o que veio, só perde as etapas vazias.
+    return [];
   }
-  return nomes;
 }
 
-function montarFunil(
-  leads: LeadDoKommo[],
-  nomes: Map<number, string>,
-  deEntrada: number,
-): TableBlock {
+function montarFunil(leads: LeadDoKommo[], etapas: EtapaDoFunil[], deEntrada: number): TableBlock {
   const porEtapa = new Map<number, { negocios: number; valor: number }>();
   for (const lead of leads) {
     const id = lead.status_id ?? 0;
@@ -221,30 +237,40 @@ function montarFunil(
     porEtapa.set(id, atual);
   }
 
+  const linha = (etapa: string, id: number) => {
+    const dados = porEtapa.get(id) ?? { negocios: 0, valor: 0 };
+    return { etapa, negocios: dados.negocios, valor: Math.round(dados.valor * 100) / 100 };
+  };
+
+  // A fila de entrada abre a tabela: é a porta, não uma etapa do funil.
+  const rows =
+    deEntrada > 0
+      ? [{ etapa: "Leads de entrada (a organizar)", negocios: deEntrada, valor: 0 }]
+      : [];
+
+  // Todas as etapas, na ordem do funil, inclusive as zeradas.
+  for (const etapa of etapas) rows.push(linha(etapa.nome, etapa.id));
+
+  // O que apareceu nos negócios mas não está no esqueleto — outro funil, ou
+  // etapa apagada depois de o negócio passar por ela. Vai ao fim em vez de
+  // sumir da conta.
+  const conhecidas = new Set(etapas.map((e) => e.id));
+  for (const [id] of porEtapa) {
+    if (conhecidas.has(id)) continue;
+    const nome = id === GANHO ? "Venda ganha" : id === PERDIDO ? "Perdido" : `Etapa ${id}`;
+    rows.push(linha(nome, id));
+  }
+
   return {
     title: "Negócios por etapa",
-    description: "Onde os negócios do período estão parados, e quanto há em cada etapa.",
+    description:
+      "Onde os negócios do período estão parados. Na ordem do funil, com as etapas vazias à vista — etapa sem ninguém é o gargalo.",
     columns: [
       { key: "etapa", label: "Etapa", align: "left" },
       { key: "negocios", label: "Negócios", format: "integer", align: "right" },
       { key: "valor", label: "Valor", format: "currency", align: "right" },
     ],
-    rows: [...porEtapa.entries()]
-      .map(([id, dados]) => ({
-        etapa:
-          nomes.get(id) ??
-          (id === GANHO ? "Venda ganha" : id === PERDIDO ? "Perdido" : `Etapa ${id}`),
-        negocios: dados.negocios,
-        valor: Math.round(dados.valor * 100) / 100,
-      }))
-      .concat(
-        // No topo da lista e fora da ordenação: é a porta de entrada, não uma
-        // etapa concorrendo por volume.
-        deEntrada > 0
-          ? [{ etapa: "Leads de entrada (a organizar)", negocios: deEntrada, valor: 0 }]
-          : [],
-      )
-      .sort((a, b) => b.negocios - a.negocios),
+    rows,
   };
 }
 

--- a/src/server/reports.ts
+++ b/src/server/reports.ts
@@ -73,7 +73,7 @@ function attachComparison(report: ChannelReport, previous: ChannelReport): Kpi[]
   const anteriores = new Map(previous.kpis.map((kpi) => [kpi.key, kpi.value]));
 
   return report.kpis.map((kpi) => {
-    if (kpi.previousValue !== undefined) return kpi;
+    if (kpi.previousValue !== undefined || kpi.semComparacao) return kpi;
 
     const anterior = anteriores.get(kpi.key);
     // KPI sem correspondente fica sem comparação, em vez de comparar contra

--- a/tests/integration/kommo.test.ts
+++ b/tests/integration/kommo.test.ts
@@ -35,7 +35,10 @@ interface LeadFalso {
  * devolver o mesmo conjunto para as duas esconderia justamente o que separa
  * "quantos entraram" de "quanto vendemos".
  */
-function kommo(leads: LeadFalso[], etapas: Array<{ id: number; name: string }> = []) {
+function kommo(
+  leads: LeadFalso[],
+  etapas: Array<{ id: number; name: string; sort?: number }> = [],
+) {
   return vi.fn(async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input.toString();
 
@@ -65,7 +68,10 @@ function kommo(leads: LeadFalso[], etapas: Array<{ id: number; name: string }> =
   });
 }
 
-async function relatorio(leads: LeadFalso[], etapas?: Array<{ id: number; name: string }>) {
+async function relatorio(
+  leads: LeadFalso[],
+  etapas?: Array<{ id: number; name: string; sort?: number }>,
+) {
   const chamadas = kommo(leads, etapas);
   vi.stubGlobal("fetch", chamadas);
   const { fetchVendasReport } = await import("@/server/connectors/kommo");
@@ -445,6 +451,63 @@ describe("vendas pelo Kommo", () => {
     expect(funil?.rows.find((r) => String(r.etapa).startsWith("Leads de entrada"))?.negocios).toBe(
       2,
     );
+  });
+
+  it("mostra todas as etapas do funil, na ordem, inclusive as vazias", async () => {
+    const { report } = await relatorio(
+      [{ id: 1, status_id: 20, created_at: emSegundos("2026-02-03T10:00:00Z") }],
+      [
+        { id: 20, name: "Novo lead", sort: 10 },
+        { id: 30, name: "Qualificação", sort: 20 },
+        { id: 40, name: "Negociação", sort: 30 },
+      ],
+    );
+
+    const funil = report.tables.find((t) => t.title === "Negócios por etapa");
+
+    // Etapa vazia sumindo esconde o gargalo: "ninguém chega em Negociação" é a
+    // informação mais útil que um funil dá.
+    expect(funil?.rows.map((r) => r.etapa)).toEqual(["Novo lead", "Qualificação", "Negociação"]);
+    expect(funil?.rows.map((r) => r.negocios)).toEqual([1, 0, 0]);
+  });
+
+  it("não reordena o funil por volume", async () => {
+    const { report } = await relatorio(
+      [
+        { id: 1, status_id: 30, created_at: emSegundos("2026-02-03T10:00:00Z") },
+        { id: 2, status_id: 30, created_at: emSegundos("2026-02-04T10:00:00Z") },
+        { id: 3, status_id: 20, created_at: emSegundos("2026-02-05T10:00:00Z") },
+      ],
+      [
+        { id: 20, name: "Novo lead", sort: 10 },
+        { id: 30, name: "Qualificação", sort: 20 },
+      ],
+    );
+
+    const funil = report.tables.find((t) => t.title === "Negócios por etapa");
+
+    // Ordenado por volume, "Qualificação" viria primeiro — e a tabela deixaria
+    // de ser um funil para virar uma lista de campeões.
+    expect(funil?.rows.map((r) => r.etapa)).toEqual(["Novo lead", "Qualificação"]);
+  });
+
+  it("etapa fora do esqueleto vai para o fim, em vez de sumir", async () => {
+    const { report } = await relatorio(
+      [
+        { id: 1, status_id: 20, created_at: emSegundos("2026-02-03T10:00:00Z") },
+        // Ganho não é etapa do funil: vem depois, sem ser descartado.
+        {
+          id: 2,
+          status_id: GANHO,
+          created_at: emSegundos("2026-02-04T10:00:00Z"),
+          closed_at: emSegundos("2026-02-05T10:00:00Z"),
+        },
+      ],
+      [{ id: 20, name: "Novo lead", sort: 10 }],
+    );
+
+    const funil = report.tables.find((t) => t.title === "Negócios por etapa");
+    expect(funil?.rows.map((r) => r.etapa)).toEqual(["Novo lead", "Venda ganha"]);
   });
 
   it("usa o nome real da etapa, e não o número", async () => {

--- a/tests/integration/kommo.test.ts
+++ b/tests/integration/kommo.test.ts
@@ -330,10 +330,21 @@ describe("vendas pelo Kommo", () => {
     const chamadas = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url.includes("/leads/unsorted")) {
-        return new Response(JSON.stringify({ _embedded: { unsorted: [{}, {}, {}] } }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        });
+        return new Response(
+          JSON.stringify({
+            _embedded: {
+              unsorted: [
+                { created_at: emSegundos("2026-02-05T10:00:00Z") },
+                { created_at: emSegundos("2026-02-06T10:00:00Z") },
+                { created_at: emSegundos("2026-02-07T10:00:00Z") },
+              ],
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
       }
       if (url.includes("/leads/pipelines")) {
         return new Response(JSON.stringify({ _embedded: { pipelines: [] } }), {
@@ -359,6 +370,80 @@ describe("vendas pelo Kommo", () => {
     // Sem essa linha o funil perde o topo — é por ali que tudo entra.
     expect(funil?.rows.find((r) => String(r.etapa).startsWith("Leads de entrada"))?.negocios).toBe(
       3,
+    );
+  });
+
+  it("sem venda no período, métrica derivada não vira -100%", async () => {
+    const { report } = await relatorio([
+      { id: 1, status_id: 20, created_at: emSegundos("2026-02-10T10:00:00Z") },
+    ]);
+
+    const marca = (chave: string) => report.kpis.find((k) => k.key === chave)?.semComparacao;
+
+    // Ticket e ciclo em zero não querem dizer "caiu para zero", e sim "não
+    // houve o que medir". No ciclo, a seta de queda sairia verde — como se
+    // fechar nada fosse melhora.
+    expect(marca("ticket")).toBe(true);
+    expect(marca("ciclo")).toBe(true);
+    // Vendas e receita continuam comparáveis: zero ali é um fato, não ausência.
+    expect(marca("vendas")).toBeFalsy();
+    expect(marca("receita")).toBeFalsy();
+  });
+
+  it("com venda no período, a comparação volta", async () => {
+    const { report } = await relatorio([
+      {
+        id: 1,
+        price: 900,
+        status_id: GANHO,
+        created_at: emSegundos("2026-02-03T10:00:00Z"),
+        closed_at: emSegundos("2026-02-05T10:00:00Z"),
+      },
+    ]);
+
+    expect(report.kpis.find((k) => k.key === "ticket")?.semComparacao).toBeFalsy();
+    expect(report.kpis.find((k) => k.key === "ciclo")?.semComparacao).toBeFalsy();
+  });
+
+  it("os leads de entrada respeitam o período da tela", async () => {
+    const chamadas = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/leads/unsorted")) {
+        return new Response(
+          JSON.stringify({
+            _embedded: {
+              unsorted: [
+                { created_at: emSegundos("2026-02-10T10:00:00Z") },
+                { created_at: emSegundos("2026-02-11T10:00:00Z") },
+                // Fora da janela: a fila é acumulada, a tabela é do período.
+                { created_at: emSegundos("2025-11-01T10:00:00Z") },
+              ],
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url.includes("/leads/pipelines")) {
+        return new Response(JSON.stringify({ _embedded: { pipelines: [] } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ _embedded: { leads: [] } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", chamadas);
+
+    const { fetchVendasReport } = await import("@/server/connectors/kommo");
+    const report = await fetchVendasReport(RANGE);
+    const funil = report.tables.find((t) => t.title === "Negócios por etapa");
+
+    // A tabela promete "os negócios do período"; a fila inteira ali dentro
+    // fazia o total não fechar com nada.
+    expect(funil?.rows.find((r) => String(r.etapa).startsWith("Leads de entrada"))?.negocios).toBe(
+      2,
     );
   });
 


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — os três defeitos apareceram nos prints da tela com a conta
real conectada, num período **sem nenhuma venda fechada**. Abro a Issue de
Correção referenciando este PR.

## Contexto

A investigação do "17 vendas ganhas" terminou bem: o número certo é **0**, e é
o que a tela mostra agora. Mas o período vazio expôs defeitos que dado cheio
escondia.

## 1. A tabela do funil misturava escopos

A linha **"Leads de entrada"** trazia a fila inteira do Kommo — acumulada desde
sempre — dentro de uma tabela cujo subtítulo promete *"os negócios do
período"*.

Na tela: 10 em "Leads de entrada", 2 em "Novo lead", 1 em "Clientes inativos",
e o indicador "Em aberto" dizendo 2. **Nenhum total fechava com nenhum outro.**

Agora ela respeita a mesma janela das demais linhas.

## 2. Métrica derivada virava "-100%", e o ciclo saía verde

Sem venda no período, **ticket médio** e **ciclo de fechamento** ficam em zero
— e zero ali não quer dizer "caiu para zero", quer dizer **"não houve o que
medir"**.

A tela comparava com o período anterior mesmo assim e estampava `-100,0%` com
seta em cada um. No ciclo de fechamento, que é melhor quando menor, **a seta
saía verde**: não ter fechado nenhuma venda lido como melhora.

`Kpi` ganha `semComparacao`, e `attachComparison` respeita. A tela mostra
"sem base de comparação", que é a verdade.

**Vendas e receita continuam comparáveis** — zero ali é um fato medido, não
ausência de medição.

## 3. O funil não era um funil

Comparando o quadro do Kommo com a tabela do painel, duas coisas não batiam — e
as duas escondiam justamente o que um funil serve para mostrar.

**Etapa vazia sumia.** A tabela nascia dos negócios encontrados, então
Qualificação, Negociação e Em pagamento, todas em zero, não apareciam em lugar
nenhum. Só que "ninguém chega em Negociação" é a informação mais útil que
aquele quadro dá: some a etapa, some o gargalo.

**E a ordem era por volume.** Uma tabela de funil fora da ordem do funil deixa
de ser funil e vira lista de campeões — não dá para ler onde o processo trava
se as etapas trocam de lugar conforme o mês.

Agora as etapas vêm da própria definição do funil (`GET /leads/pipelines`), na
ordem do `sort` do Kommo, todas elas, com zero à vista, restritas a
`KOMMO_PIPELINE_ID` quando ele existe. O que aparecer nos negócios sem estar no
esqueleto — ganho, perdido, etapa apagada depois — vai para o fim em vez de
sumir da conta.

## Como foi validado

- [x] `npm run verify` — **240 testes**, lint, tipos e contrato de arquitetura
- [x] `npm run test:e2e` — 46/46
- [x] `npm run build` limpo

Testes novos: a fila de entrada recortada pela janela (registro de novembro
fora, dois de fevereiro dentro); ticket e ciclo marcados sem comparação quando
não houve venda; vendas e receita **não** marcados; a comparação voltando assim
que existe uma venda; e o esqueleto do funil com etapa zerada presente e na
ordem do `sort`.

O teste anterior da fila de entrada usava registros sem data e passou a falhar
— corretamente, porque agora a data é o que decide. A isca foi corrigida, não o
código.

## Riscos e limitações

**A fila de entrada é acumulada por natureza.** Recortá-la pelo período torna a
linha coerente com a tabela, mas quem quiser saber "quantos estão esperando
para ser organizados" não vê mais esse número no painel — está no Kommo.

**`semComparacao` é decisão do conector**, não regra geral. Outros canais podem
ter o mesmo problema com métricas derivadas em período vazio; não fui atrás
agora.

**Uma chamada a mais por carregamento** (`/leads/pipelines`) para montar o
esqueleto. É barata e cacheável, mas hoje não está cacheada.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_