### PR TITLE
feat: a tela de Vendas ganha motivos de perda e o funil em figura

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -108,11 +108,16 @@ tela de entrada —, então a superfície é fixa em `#2f2535` e a rampa é vali
 uma vez só em vez de duas. Sobre fundo escuro quem tem mais volume precisa de
 mais luz: a ordem vai do passo mais claro para o mais fechado.
 
-**A lâmina é uma pílula, não um trapézio.** A marca é arredondada em tudo — slab
-de 28px na navegação, pílula nos filtros e nos botões —, e um trapézio de quina
-viva no meio da tela briga com o que está em volta. A lâmina tem 60px de altura
-e raio total, o que dá justamente os 30px do slab. A silhueta de funil vem das
-larguras decrescentes, não do chanfro.
+**Cone contínuo, com boca e bica arredondadas.** As faixas se encostam — 2px de
+superfície entre elas, o mesmo respiro de qualquer marca colada do painel — e
+formam uma peça só, em vez de blocos empilhados. Recorte poligonal não aceita
+raio, então a boca e a bica ganham uma tampa própria: retângulo de raio total na
+mesma largura da aresta, encaixado sem costura. É o que tira a quina viva de uma
+interface arredondada em todo o resto.
+
+O degradê de cada faixa é **horizontal**. Tampa e corpo são elementos separados,
+e qualquer componente vertical mudaria de tom entre os dois, deixando emenda
+visível justo na aresta que deveria ser lisa.
 
 Três regras que o componente cumpre:
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -99,17 +99,23 @@ bolha, small multiples) usam no máximo **3 slots**. Acima disso o gate
 all-pairs reprova. `maxSlotsFor("all-pairs")` devolve esse número, e há teste
 travando a regra.
 
-Rampa ordinal (funil, faixas): lilás em 5 passos, `--qy-funnel-1..5`.
+Rampa ordinal (funil): lilás em 5 passos, `--qy-funnel-1..5`, mais
+`--qy-funnel-ganho` para o desfecho.
 
-**Ela não é a mesma nos dois temas.** No claro o passo mais escuro abre o funil,
-onde há mais negócio; no escuro a ordem inverte, porque sobre `#2f2535` quem tem
-mais volume precisa de mais luz, não de menos — `#66417b` quase some contra o
-fundo. É o mesmo princípio dos papéis semânticos: o tema escuro tem passos
-próprios, não é inversão automática.
+**Ela é a mesma nos dois temas, e fica fora dos blocos de tema.** O funil
+(`FunnelChart`) mora sempre no slab escuro da marca — o mesmo da navegação e da
+tela de entrada —, então a superfície é fixa em `#2f2535` e a rampa é validada
+uma vez só em vez de duas. Sobre fundo escuro quem tem mais volume precisa de
+mais luz: a ordem vai do passo mais claro para o mais fechado.
 
-O funil (`FunnelChart`) usa **largura** como única codificação de grandeza; a cor
-só ordena. O desfecho — "Venda ganha" — sai da rampa e vem com ícone e rótulo,
-porque cor trocada sozinha não avisa que a categoria mudou.
+Três regras que o componente cumpre:
+
+- **Largura é a única codificação de grandeza.** A cor apenas ordena.
+- **O desfecho sai da rampa.** "Venda ganha" não é etapa de passagem: vem em
+  verde, com troféu e rótulo — cor trocada sozinha não avisa que a categoria
+  mudou.
+- **Etapa zerada mantém um traço visível.** "Ninguém chega aqui" é a informação
+  mais útil que um funil dá; largura zero levaria o rótulo junto.
 
 ---
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -99,8 +99,17 @@ bolha, small multiples) usam no máximo **3 slots**. Acima disso o gate
 all-pairs reprova. `maxSlotsFor("all-pairs")` devolve esse número, e há teste
 travando a regra.
 
-Rampa ordinal (funil, faixas): lilás em 5 passos, também validada
-(`--ordinal`, monotonia e contraste da ponta clara aprovados).
+Rampa ordinal (funil, faixas): lilás em 5 passos, `--qy-funnel-1..5`.
+
+**Ela não é a mesma nos dois temas.** No claro o passo mais escuro abre o funil,
+onde há mais negócio; no escuro a ordem inverte, porque sobre `#2f2535` quem tem
+mais volume precisa de mais luz, não de menos — `#66417b` quase some contra o
+fundo. É o mesmo princípio dos papéis semânticos: o tema escuro tem passos
+próprios, não é inversão automática.
+
+O funil (`FunnelChart`) usa **largura** como única codificação de grandeza; a cor
+só ordena. O desfecho — "Venda ganha" — sai da rampa e vem com ícone e rótulo,
+porque cor trocada sozinha não avisa que a categoria mudou.
 
 ---
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -108,6 +108,12 @@ tela de entrada —, então a superfície é fixa em `#2f2535` e a rampa é vali
 uma vez só em vez de duas. Sobre fundo escuro quem tem mais volume precisa de
 mais luz: a ordem vai do passo mais claro para o mais fechado.
 
+**A lâmina é uma pílula, não um trapézio.** A marca é arredondada em tudo — slab
+de 28px na navegação, pílula nos filtros e nos botões —, e um trapézio de quina
+viva no meio da tela briga com o que está em volta. A lâmina tem 60px de altura
+e raio total, o que dá justamente os 30px do slab. A silhueta de funil vem das
+larguras decrescentes, não do chanfro.
+
 Três regras que o componente cumpre:
 
 - **Largura é a única codificação de grandeza.** A cor apenas ordena.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,6 +127,13 @@
   --qy-chart-surface: #ffffff;
   --qy-grid: #ece8f2;
   --qy-axis: #d7d2e1;
+  /* Rampa ordinal do funil: um hue só, escurecendo com o volume. Sobre fundo
+     claro o passo mais escuro fica no topo, que é onde há mais negócio. */
+  --qy-funnel-1: #66417b;
+  --qy-funnel-2: #8248a8;
+  --qy-funnel-3: #9d5cc1;
+  --qy-funnel-4: #b27fd0;
+  --qy-funnel-5: #c9a3de;
 }
 
 /* ---- Tema escuro -------------------------------------------------------
@@ -155,6 +162,14 @@
     --qy-chart-surface: #2f2535;
     --qy-grid: #3d3247;
     --qy-axis: #4d4159;
+    /* Invertida, e não a mesma de cima: sobre fundo escuro quem tem mais
+       volume precisa de mais luz, não de menos. O passo #66417b, que abre o
+       funil no tema claro, quase desaparece contra #2f2535. */
+    --qy-funnel-1: #d9bced;
+    --qy-funnel-2: #c9a3de;
+    --qy-funnel-3: #b27fd0;
+    --qy-funnel-4: #9d5cc1;
+    --qy-funnel-5: #8248a8;
   }
 }
 
@@ -180,6 +195,11 @@
   --qy-chart-surface: #2f2535;
   --qy-grid: #3d3247;
   --qy-axis: #4d4159;
+  --qy-funnel-1: #d9bced;
+  --qy-funnel-2: #c9a3de;
+  --qy-funnel-3: #b27fd0;
+  --qy-funnel-4: #9d5cc1;
+  --qy-funnel-5: #8248a8;
 }
 
 /* ---- Base --------------------------------------------------------------- */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,13 +127,22 @@
   --qy-chart-surface: #ffffff;
   --qy-grid: #ece8f2;
   --qy-axis: #d7d2e1;
-  /* Rampa ordinal do funil: um hue só, escurecendo com o volume. Sobre fundo
-     claro o passo mais escuro fica no topo, que é onde há mais negócio. */
-  --qy-funnel-1: #66417b;
-  --qy-funnel-2: #8248a8;
-  --qy-funnel-3: #9d5cc1;
-  --qy-funnel-4: #b27fd0;
-  --qy-funnel-5: #c9a3de;
+}
+
+/* ---- Rampa ordinal do funil ---------------------------------------------
+   Fora dos blocos de tema de propósito: o funil mora sempre no slab escuro da
+   marca, nos dois temas, e superfície fixa é o que permite validar a rampa uma
+   vez só em vez de manter duas. Sobre #2f2535 quem tem mais volume precisa de
+   mais luz, então a ordem vai do passo mais claro para o mais fechado. */
+:root {
+  --qy-funnel-1: #e6d4f2;
+  --qy-funnel-2: #d0aee6;
+  --qy-funnel-3: #b27fd0;
+  --qy-funnel-4: #9d5cc1;
+  --qy-funnel-5: #8248a8;
+  /* O desfecho sai da rampa: é outra categoria de coisa, e vem com ícone e
+     rótulo junto — a cor sozinha nunca diz isso. */
+  --qy-funnel-ganho: #4bb37c;
 }
 
 /* ---- Tema escuro -------------------------------------------------------
@@ -162,14 +171,6 @@
     --qy-chart-surface: #2f2535;
     --qy-grid: #3d3247;
     --qy-axis: #4d4159;
-    /* Invertida, e não a mesma de cima: sobre fundo escuro quem tem mais
-       volume precisa de mais luz, não de menos. O passo #66417b, que abre o
-       funil no tema claro, quase desaparece contra #2f2535. */
-    --qy-funnel-1: #d9bced;
-    --qy-funnel-2: #c9a3de;
-    --qy-funnel-3: #b27fd0;
-    --qy-funnel-4: #9d5cc1;
-    --qy-funnel-5: #8248a8;
   }
 }
 
@@ -195,11 +196,6 @@
   --qy-chart-surface: #2f2535;
   --qy-grid: #3d3247;
   --qy-axis: #4d4159;
-  --qy-funnel-1: #d9bced;
-  --qy-funnel-2: #c9a3de;
-  --qy-funnel-3: #b27fd0;
-  --qy-funnel-4: #9d5cc1;
-  --qy-funnel-5: #8248a8;
 }
 
 /* ---- Base --------------------------------------------------------------- */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -135,11 +135,11 @@
    vez só em vez de manter duas. Sobre #2f2535 quem tem mais volume precisa de
    mais luz, então a ordem vai do passo mais claro para o mais fechado. */
 :root {
-  --qy-funnel-1: #e6d4f2;
-  --qy-funnel-2: #d0aee6;
+  --qy-funnel-1: #e0cbee;
+  --qy-funnel-2: #c9a3de;
   --qy-funnel-3: #b27fd0;
   --qy-funnel-4: #9d5cc1;
-  --qy-funnel-5: #8248a8;
+  --qy-funnel-5: #8a4fb0;
   /* O desfecho sai da rampa: é outra categoria de coisa, e vem com ícone e
      rótulo junto — a cor sozinha nunca diz isso. */
   --qy-funnel-ganho: #4bb37c;

--- a/src/components/charts/funnel-chart.tsx
+++ b/src/components/charts/funnel-chart.tsx
@@ -1,5 +1,6 @@
 import { Trophy } from "lucide-react";
 
+import { LightBlock } from "@/components/brand/light-block";
 import { cn } from "@/lib/cn";
 import { formatMetric } from "@/lib/format";
 import type { FunnelBlock, FunnelStage } from "@/lib/types";
@@ -7,23 +8,35 @@ import type { FunnelBlock, FunnelStage } from "@/lib/types";
 /**
  * O funil comercial, em figura.
  *
- * Uma pilha de trapézios: a largura de cada aresta é o número daquela etapa, e
- * a inclinação entre duas arestas é a perda entre elas. Ler o estrangulamento
- * vira ver onde a figura aperta — que é a única coisa que um funil desenhado
- * faz melhor que a tabela ao lado.
+ * Faixas separadas, cada uma um trapézio: a aresta de cima é o número da etapa,
+ * a de baixo é o da próxima, e o quanto ela estreita é a perda entre as duas.
+ * Onde a forma aperta é onde o processo trava — que é a única coisa que um
+ * funil desenhado faz melhor que a tabela ao lado.
+ *
+ * **Mora no slab escuro da marca, nos dois temas.** Não é escolha de gosto: uma
+ * rampa de um hue só precisa de uma superfície fixa para ter contraste
+ * garantido, e alternar a superfície obrigaria a manter duas rampas validadas
+ * em vez de uma. O slab é o mesmo da navegação e da tela de entrada, então a
+ * peça mais chamativa do painel continua sendo a marca, e não uma exceção.
  *
  * **Sem tooltip, de propósito.** A regra da casa é que gráfico em HTML tem
  * camada de hover; a exceção aqui é que não há nada escondido para revelar —
- * etapa, contagem, porcentagem e queda estão todas escritas na tela, ao lado
- * da forma. Um tooltip repetiria o que já está visível e ainda esconderia o
- * dado de quem navega por teclado.
+ * etapa, contagem, porcentagem e queda estão todas escritas ao lado da forma.
+ * Um tooltip repetiria o visível e ainda esconderia o dado de quem navega por
+ * teclado.
  *
- * A largura é a única codificação de grandeza. A cor apenas ordena, na rampa
- * de um hue só — e o desfecho, que não é etapa de passagem, sai da rampa e vem
- * com ícone e rótulo, nunca só com a cor trocada.
+ * A largura é a única codificação de grandeza. A cor apenas ordena — e o
+ * desfecho, que não é etapa de passagem, sai da rampa e vem com ícone e
+ * rótulo, nunca só com a cor trocada.
  */
 
-/** Passos da rampa ordinal, do topo do funil para a base. */
+/**
+ * A rampa, do topo do funil para a base.
+ *
+ * Validada contra `#2f2535`, que é a superfície onde ela sempre aparece. Sobre
+ * fundo escuro quem tem mais volume precisa de mais luz, não de menos: a
+ * ordem é do passo mais claro para o mais fechado.
+ */
 const RAMPA = [
   "var(--qy-funnel-1)",
   "var(--qy-funnel-2)",
@@ -35,8 +48,8 @@ const RAMPA = [
 /**
  * Uma cor da rampa para cada etapa, distribuídas de ponta a ponta.
  *
- * Com três etapas o funil usa o primeiro, o do meio e o último passo — e não
- * os três primeiros. Assim a diferença entre a boca e o fim é sempre a mesma,
+ * Com três etapas o funil usa o primeiro, o do meio e o último passo — e não os
+ * três primeiros. Assim a diferença entre a boca e o fim é sempre a mesma,
  * independentemente de quantas etapas a clínica tenha criado no CRM.
  */
 function corDaEtapa(indice: number, total: number): string {
@@ -46,39 +59,26 @@ function corDaEtapa(indice: number, total: number): string {
 }
 
 /**
- * Largura da aresta, em porcentagem da boca do funil.
+ * A boca do funil não encosta na borda do slab.
  *
- * O piso de 3% existe para etapa zerada continuar sendo uma linha visível em
- * vez de sumir: "ninguém chega aqui" é informação, e uma forma de largura zero
- * some junto com a linha inteira, levando o rótulo embora. O número ao lado
- * continua dizendo zero — a figura nunca é a fonte do valor.
- */
-const PISO = 3;
-
-/**
- * A boca do funil não encosta na borda do cartão.
- *
- * Sem folga a primeira faixa termina rente ao corte da superfície e passa a
- * ler como forma cortada, e não como forma larga — o desenho parece um erro de
+ * Sem folga a primeira faixa termina rente ao corte da superfície e passa a ler
+ * como forma cortada, e não como forma larga — o desenho parece um erro de
  * layout justamente na etapa mais importante.
  */
-const BOCA = 92;
+const BOCA = 94;
+
+/**
+ * Piso de largura da aresta.
+ *
+ * Etapa zerada continua sendo uma faixa visível em vez de sumir: "ninguém chega
+ * aqui" é informação, e largura zero levaria o rótulo junto. O número ao lado
+ * continua dizendo zero — a figura nunca é a fonte do valor.
+ */
+const PISO = 6;
 
 function largura(valor: number, topo: number): number {
   if (topo <= 0) return PISO;
   return Math.max(PISO, (valor / topo) * BOCA);
-}
-
-/**
- * Porcentagem em número inteiro.
- *
- * O formatador da casa leva duas casas, que é o certo para uma taxa de
- * conversão comparada mês a mês. Aqui não: "−59,22%" ao lado de uma forma
- * geométrica finge uma precisão que a figura não tem, e o que se lê é a ordem
- * de grandeza da queda.
- */
-function porcento(fracao: number): string {
-  return `${Math.round(fracao * 100)}%`;
 }
 
 function trapezio(cima: number, baixo: number): string {
@@ -87,6 +87,11 @@ function trapezio(cima: number, baixo: number): string {
   const c = (100 + baixo) / 2;
   const d = (100 - baixo) / 2;
   return `polygon(${a}% 0%, ${b}% 0%, ${c}% 100%, ${d}% 100%)`;
+}
+
+/** Porcentagem em número inteiro: a figura não tem duas casas de precisão. */
+function porcento(fracao: number): string {
+  return `${Math.round(fracao * 100)}%`;
 }
 
 function Faixa({
@@ -100,33 +105,52 @@ function Faixa({
   baixo: number;
   cor: string;
 }) {
+  const recorte = trapezio(cima, baixo);
+
   return (
     <div
       aria-hidden="true"
-      className="relative h-full w-full transition-transform duration-[var(--duration-base)] ease-[var(--ease-out-soft)] group-hover:scale-y-[1.04]"
+      className="relative h-full w-full transition-transform duration-[var(--duration-base)] ease-[var(--ease-out-soft)] group-hover:scale-[1.02]"
     >
       <div
         className="absolute inset-0"
-        style={{ clipPath: trapezio(cima, baixo), background: cor }}
-      />
-      {/* Recorte de luz do brandbook, o mesmo da navegação: dá volume à forma
-          sem inventar uma segunda cor. */}
-      <div
-        className="absolute inset-0 opacity-[0.18] mix-blend-overlay"
         style={{
-          clipPath: trapezio(cima, baixo),
-          background: "linear-gradient(160deg, #ffffff 0%, transparent 55%)",
+          clipPath: recorte,
+          // Um degradê dentro do mesmo passo: dá volume à faixa sem introduzir
+          // uma segunda cor, que quebraria a leitura de rampa.
+          background: `linear-gradient(115deg, ${cor} 0%, color-mix(in oklab, ${cor} 74%, #17111b) 100%)`,
+        }}
+      />
+      {/* Fio de luz na aresta de cima — o mesmo brilho do slab da marca, que é
+          o que dá a impressão de peça empilhada. */}
+      <div
+        className="absolute inset-0 opacity-45"
+        style={{
+          clipPath: recorte,
+          background: "linear-gradient(180deg, rgba(255,255,255,0.55) 0%, transparent 34%)",
         }}
       />
       {etapa.outcome === "ganho" ? (
-        <div
-          className="absolute inset-0 grid place-items-center"
-          style={{ clipPath: trapezio(cima, baixo) }}
-        >
-          <Trophy className="size-4 text-white/90" />
+        <div className="absolute inset-0 grid place-items-center" style={{ clipPath: recorte }}>
+          <Trophy className="size-5 text-plum-900" />
         </div>
       ) : null}
     </div>
+  );
+}
+
+/** Fio que liga a caixa de texto à faixa, como num diagrama de apresentação. */
+function Fio({ lado }: { lado: "esquerda" | "direita" }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "hidden h-px w-4 shrink-0 sm:block",
+        lado === "esquerda"
+          ? "bg-gradient-to-r from-transparent to-white/25"
+          : "bg-gradient-to-l from-transparent to-white/25",
+      )}
+    />
   );
 }
 
@@ -137,76 +161,78 @@ export function FunnelChart({ block }: { block: FunnelBlock }) {
   const topo = etapas[0]?.value ?? 0;
 
   return (
-    <figure className="qy-fade">
+    <figure className="qy-fade relative overflow-hidden rounded-[var(--radius-slab)] bg-plum-800 px-4 py-6 text-white sm:px-6 sm:py-8">
+      <LightBlock className="opacity-70" />
+
       <figcaption className="sr-only">
         {block.title}
         {block.description ? `. ${block.description}` : ""}
       </figcaption>
 
-      <ol className="space-y-0">
+      <ol className="relative space-y-2">
         {etapas.map((etapa, i) => {
           const proxima = etapas[i + 1];
           const cima = largura(etapa.value, topo);
           const baixo = largura(proxima?.value ?? etapa.value, topo);
           const doTopo = topo === 0 ? 0 : etapa.value / topo;
-          // Queda em relação à etapa anterior, que é a leitura que interessa:
-          // "de Qualificação para Negociação some metade".
           const anterior = etapas[i - 1]?.value;
           const queda =
             anterior === undefined || anterior === 0 ? null : 1 - etapa.value / anterior;
+          const cor =
+            etapa.outcome === "ganho" ? "var(--qy-funnel-ganho)" : corDaEtapa(i, etapas.length);
 
           return (
             <li
               key={etapa.label}
-              className="group grid grid-cols-[1fr_auto] items-stretch gap-3 sm:grid-cols-[minmax(0,11rem)_1fr_auto] sm:gap-4"
+              className="group grid grid-cols-2 items-center gap-x-3 gap-y-1 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)_minmax(0,1fr)] sm:gap-x-4"
             >
-              {/* Rótulo fora da forma: nome de etapa longo não cabe dentro de
-                  um trapézio estreito, e texto sobre a rampa perderia contraste
-                  justamente nos passos claros. */}
-              <div className="flex flex-col justify-center py-1 sm:py-0">
-                <div className="flex items-center gap-1.5">
-                  {etapa.outcome === "ganho" ? (
-                    <Trophy aria-hidden="true" className="size-3.5 shrink-0 text-positive" />
-                  ) : null}
-                  <span
-                    className={cn(
-                      "font-medium text-sm",
-                      etapa.outcome === "ganho" ? "text-positive" : "text-ink",
-                    )}
-                  >
-                    {etapa.label}
-                  </span>
+              {/* Caixa de rótulo com filete da cor da faixa: é o que amarra o
+                  texto à forma sem escrever nada por cima do trapézio, onde
+                  nome comprido não cabe e o contraste muda a cada passo. */}
+              <div className="flex items-center">
+                <div
+                  className="min-w-0 flex-1 rounded-xl border border-white/15 bg-white/5 py-2 pr-3 pl-3"
+                  style={{ borderLeft: `3px solid ${cor}` }}
+                >
+                  <div className="flex items-center gap-1.5">
+                    {etapa.outcome === "ganho" ? (
+                      <Trophy aria-hidden="true" className="size-3.5 shrink-0 text-white" />
+                    ) : null}
+                    {/* Sem truncar: "Venda ganha" já cortava no telefone, e
+                        nome de etapa cortado é etapa que ninguém identifica. */}
+                    <span className="font-semibold text-[13px] text-white uppercase leading-tight tracking-wide">
+                      {etapa.label}
+                    </span>
+                  </div>
                 </div>
-                {queda !== null && queda > 0 ? (
-                  <span className="text-[11px] text-ink-muted tabular-nums">
-                    −{porcento(queda)} da etapa anterior
-                  </span>
-                ) : null}
+                <Fio lado="esquerda" />
               </div>
 
               {/* A forma. Some no telefone: com a tela estreita o trapézio fica
                   raso demais para dizer alguma coisa, e o que sobra — nome,
                   contagem e queda — já é o funil em texto. */}
-              <div className="hidden h-16 py-[2px] sm:block">
-                <Faixa
-                  etapa={etapa}
-                  cima={cima}
-                  baixo={baixo}
-                  cor={
-                    etapa.outcome === "ganho"
-                      ? "var(--color-positive)"
-                      : corDaEtapa(i, etapas.length)
-                  }
-                />
+              <div className="col-span-2 hidden h-16 sm:col-span-1 sm:block">
+                <Faixa etapa={etapa} cima={cima} baixo={baixo} cor={cor} />
               </div>
 
-              <div className="flex flex-col items-end justify-center py-1 sm:py-0">
-                <span className="font-semibold text-base text-ink tabular-nums">
-                  {formatMetric(etapa.value, "integer")}
-                </span>
-                <span className="text-[11px] text-ink-muted tabular-nums">
-                  {porcento(doTopo)} do topo
-                </span>
+              <div className="flex items-center justify-end">
+                <Fio lado="direita" />
+                <div className="flex flex-1 items-center justify-between gap-3 rounded-xl border border-white/15 bg-white/5 px-3.5 py-2">
+                  <span className="font-semibold text-lg text-white tabular-nums">
+                    {formatMetric(etapa.value, "integer")}
+                  </span>
+                  {/* Duas linhas curtas, e não três informações numa só: na
+                      largura desta coluna "da etapa anterior" quebra no meio e
+                      o número perde o rótulo. */}
+                  <span className="text-right text-[11px] text-plum-200 leading-tight tabular-nums">
+                    <span className="block whitespace-nowrap">{porcento(doTopo)} do topo</span>
+                    {queda !== null && queda > 0 ? (
+                      <span className="block whitespace-nowrap text-plum-300">
+                        −{porcento(queda)} da anterior
+                      </span>
+                    ) : null}
+                  </span>
+                </div>
               </div>
             </li>
           );
@@ -214,7 +240,7 @@ export function FunnelChart({ block }: { block: FunnelBlock }) {
       </ol>
 
       {block.caveat ? (
-        <p className="mt-4 border-line border-t pt-3 text-[11px] text-ink-muted leading-relaxed">
+        <p className="relative mt-6 border-white/10 border-t pt-4 text-[11px] text-plum-300 leading-relaxed">
           {block.caveat}
         </p>
       ) : null}

--- a/src/components/charts/funnel-chart.tsx
+++ b/src/components/charts/funnel-chart.tsx
@@ -1,41 +1,39 @@
 import { Trophy } from "lucide-react";
 
 import { LightBlock } from "@/components/brand/light-block";
-import { cn } from "@/lib/cn";
 import { formatMetric } from "@/lib/format";
 import type { FunnelBlock, FunnelStage } from "@/lib/types";
 
 /**
  * O funil comercial, em figura.
  *
- * Faixas separadas, cada uma um trapézio: a aresta de cima é o número da etapa,
- * a de baixo é o da próxima, e o quanto ela estreita é a perda entre as duas.
- * Onde a forma aperta é onde o processo trava — que é a única coisa que um
- * funil desenhado faz melhor que a tabela ao lado.
+ * Lâminas empilhadas, no formato de diagrama de apresentação: cada etapa é uma
+ * lâmina própria, com folga entre elas, e a diferença de largura de uma para a
+ * outra é a perda. Caixa de rótulo à esquerda, caixa de números à direita, fio
+ * ligando as duas à lâmina — o desenho que o comercial reconhece de slide, com
+ * a paleta da casa no lugar do arco-íris de banco de imagem.
+ *
+ * **A aresta de cima de cada lâmina é o número da etapa.** É a única codificação
+ * de grandeza. Cada lâmina ainda estreita um pouco sozinha, de um valor fixo e
+ * igual para todas — isso é desenho, não dado, e é o que dá o empilhamento em
+ * vez de um cone contínuo. O que informa é o degrau **entre** lâminas.
  *
  * **Mora no slab escuro da marca, nos dois temas.** Não é escolha de gosto: uma
- * rampa de um hue só precisa de uma superfície fixa para ter contraste
- * garantido, e alternar a superfície obrigaria a manter duas rampas validadas
- * em vez de uma. O slab é o mesmo da navegação e da tela de entrada, então a
- * peça mais chamativa do painel continua sendo a marca, e não uma exceção.
+ * rampa de um hue só precisa de superfície fixa para ter contraste garantido, e
+ * alternar a superfície obrigaria a manter duas rampas validadas em vez de uma.
+ * O slab é o mesmo da navegação e da tela de entrada.
  *
- * **Sem tooltip, de propósito.** A regra da casa é que gráfico em HTML tem
- * camada de hover; a exceção aqui é que não há nada escondido para revelar —
- * etapa, contagem, porcentagem e queda estão todas escritas ao lado da forma.
- * Um tooltip repetiria o visível e ainda esconderia o dado de quem navega por
- * teclado.
- *
- * A largura é a única codificação de grandeza. A cor apenas ordena — e o
- * desfecho, que não é etapa de passagem, sai da rampa e vem com ícone e
- * rótulo, nunca só com a cor trocada.
+ * **Sem tooltip, de propósito.** Etapa, contagem, porcentagem e queda estão
+ * todas escritas ao lado da forma; um tooltip repetiria o visível e esconderia
+ * o dado de quem navega por teclado.
  */
 
 /**
  * A rampa, do topo do funil para a base.
  *
  * Validada contra `#2f2535`, que é a superfície onde ela sempre aparece. Sobre
- * fundo escuro quem tem mais volume precisa de mais luz, não de menos: a
- * ordem é do passo mais claro para o mais fechado.
+ * fundo escuro quem tem mais volume precisa de mais luz, então a ordem vai do
+ * passo mais claro para o mais fechado.
  */
 const RAMPA = [
   "var(--qy-funnel-1)",
@@ -59,29 +57,43 @@ function corDaEtapa(indice: number, total: number): string {
 }
 
 /**
- * A boca do funil não encosta na borda do slab.
+ * O passo escuro da rampa não tem contraste para virar texto.
  *
- * Sem folga a primeira faixa termina rente ao corte da superfície e passa a ler
- * como forma cortada, e não como forma larga — o desenho parece um erro de
- * layout justamente na etapa mais importante.
+ * Clarear o mesmo hue mantém a caixa visivelmente da cor da lâmina — que é o
+ * que amarra rótulo e forma — sem depender de um passo que, em corpo pequeno,
+ * ninguém lê.
  */
-const BOCA = 94;
+function paraTexto(cor: string): string {
+  return `color-mix(in oklab, ${cor} 62%, white)`;
+}
+
+/** A boca do funil não encosta na borda do slab. */
+const BOCA = 96;
 
 /**
  * Piso de largura da aresta.
  *
- * Etapa zerada continua sendo uma faixa visível em vez de sumir: "ninguém chega
- * aqui" é informação, e largura zero levaria o rótulo junto. O número ao lado
- * continua dizendo zero — a figura nunca é a fonte do valor.
+ * Etapa zerada continua sendo uma lâmina visível em vez de sumir: "ninguém
+ * chega aqui" é informação, e largura zero levaria o rótulo junto. O número ao
+ * lado continua dizendo zero — a figura nunca é a fonte do valor.
  */
-const PISO = 6;
+const PISO = 7;
+
+/**
+ * O quanto cada lâmina estreita sozinha, de cima para baixo.
+ *
+ * Constante e igual para todas: é o que faz a peça parecer empilhada em vez de
+ * um cone liso, e por ser a mesma em todas não mexe na proporção entre etapas.
+ */
+const CHANFRO = 0.84;
 
 function largura(valor: number, topo: number): number {
   if (topo <= 0) return PISO;
   return Math.max(PISO, (valor / topo) * BOCA);
 }
 
-function trapezio(cima: number, baixo: number): string {
+function lamina(cima: number): string {
+  const baixo = cima * CHANFRO;
   const a = (100 - cima) / 2;
   const b = (100 + cima) / 2;
   const c = (100 + baixo) / 2;
@@ -94,40 +106,28 @@ function porcento(fracao: number): string {
   return `${Math.round(fracao * 100)}%`;
 }
 
-function Faixa({
-  etapa,
-  cima,
-  baixo,
-  cor,
-}: {
-  etapa: FunnelStage;
-  cima: number;
-  baixo: number;
-  cor: string;
-}) {
-  const recorte = trapezio(cima, baixo);
+function Lamina({ etapa, cima, cor }: { etapa: FunnelStage; cima: number; cor: string }) {
+  const recorte = lamina(cima);
 
   return (
     <div
       aria-hidden="true"
-      className="relative h-full w-full transition-transform duration-[var(--duration-base)] ease-[var(--ease-out-soft)] group-hover:scale-[1.02]"
+      className="relative h-full w-full transition-transform duration-[var(--duration-base)] ease-[var(--ease-out-soft)] group-hover:scale-[1.03]"
     >
       <div
         className="absolute inset-0"
         style={{
           clipPath: recorte,
-          // Um degradê dentro do mesmo passo: dá volume à faixa sem introduzir
-          // uma segunda cor, que quebraria a leitura de rampa.
-          background: `linear-gradient(115deg, ${cor} 0%, color-mix(in oklab, ${cor} 74%, #17111b) 100%)`,
+          // Degradê dentro do mesmo passo, na diagonal: dá volume à lâmina sem
+          // introduzir uma segunda cor, que quebraria a leitura de rampa.
+          background: `linear-gradient(105deg, color-mix(in oklab, ${cor} 82%, white) 0%, ${cor} 46%, color-mix(in oklab, ${cor} 68%, #17111b) 100%)`,
         }}
       />
-      {/* Fio de luz na aresta de cima — o mesmo brilho do slab da marca, que é
-          o que dá a impressão de peça empilhada. */}
       <div
-        className="absolute inset-0 opacity-45"
+        className="absolute inset-0 opacity-60"
         style={{
           clipPath: recorte,
-          background: "linear-gradient(180deg, rgba(255,255,255,0.55) 0%, transparent 34%)",
+          background: "linear-gradient(180deg, rgba(255,255,255,0.5) 0%, transparent 30%)",
         }}
       />
       {etapa.outcome === "ganho" ? (
@@ -139,21 +139,6 @@ function Faixa({
   );
 }
 
-/** Fio que liga a caixa de texto à faixa, como num diagrama de apresentação. */
-function Fio({ lado }: { lado: "esquerda" | "direita" }) {
-  return (
-    <span
-      aria-hidden="true"
-      className={cn(
-        "hidden h-px w-4 shrink-0 sm:block",
-        lado === "esquerda"
-          ? "bg-gradient-to-r from-transparent to-white/25"
-          : "bg-gradient-to-l from-transparent to-white/25",
-      )}
-    />
-  );
-}
-
 export function FunnelChart({ block }: { block: FunnelBlock }) {
   const etapas = block.stages;
   if (etapas.length === 0) return null;
@@ -161,7 +146,7 @@ export function FunnelChart({ block }: { block: FunnelBlock }) {
   const topo = etapas[0]?.value ?? 0;
 
   return (
-    <figure className="qy-fade relative overflow-hidden rounded-[var(--radius-slab)] bg-plum-800 px-4 py-6 text-white sm:px-6 sm:py-8">
+    <figure className="qy-fade relative overflow-hidden rounded-[var(--radius-slab)] bg-plum-800 px-4 py-6 text-white sm:px-7 sm:py-9">
       <LightBlock className="opacity-70" />
 
       <figcaption className="sr-only">
@@ -169,61 +154,85 @@ export function FunnelChart({ block }: { block: FunnelBlock }) {
         {block.description ? `. ${block.description}` : ""}
       </figcaption>
 
-      <ol className="relative space-y-2">
+      <ol className="relative space-y-2.5">
         {etapas.map((etapa, i) => {
-          const proxima = etapas[i + 1];
           const cima = largura(etapa.value, topo);
-          const baixo = largura(proxima?.value ?? etapa.value, topo);
           const doTopo = topo === 0 ? 0 : etapa.value / topo;
           const anterior = etapas[i - 1]?.value;
           const queda =
             anterior === undefined || anterior === 0 ? null : 1 - etapa.value / anterior;
           const cor =
             etapa.outcome === "ganho" ? "var(--qy-funnel-ganho)" : corDaEtapa(i, etapas.length);
+          const tinta = paraTexto(cor);
 
           return (
             <li
               key={etapa.label}
-              className="group grid grid-cols-2 items-center gap-x-3 gap-y-1 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)_minmax(0,1fr)] sm:gap-x-4"
+              className="group grid grid-cols-2 items-center gap-x-2 gap-y-1 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.7fr)_minmax(0,1fr)] sm:gap-x-0"
             >
-              {/* Caixa de rótulo com filete da cor da faixa: é o que amarra o
-                  texto à forma sem escrever nada por cima do trapézio, onde
-                  nome comprido não cabe e o contraste muda a cada passo. */}
+              {/* Caixa de rótulo na cor da lâmina, com o fio ligando à forma —
+                  o texto fica fora do trapézio, onde nome comprido não cabe e o
+                  contraste mudaria a cada passo da rampa. */}
               <div className="flex items-center">
                 <div
-                  className="min-w-0 flex-1 rounded-xl border border-white/15 bg-white/5 py-2 pr-3 pl-3"
-                  style={{ borderLeft: `3px solid ${cor}` }}
+                  className="min-w-0 flex-1 rounded-lg border px-3 py-2.5"
+                  style={{
+                    borderColor: `color-mix(in oklab, ${cor} 55%, transparent)`,
+                    background: `color-mix(in oklab, ${cor} 9%, transparent)`,
+                  }}
                 >
                   <div className="flex items-center gap-1.5">
                     {etapa.outcome === "ganho" ? (
-                      <Trophy aria-hidden="true" className="size-3.5 shrink-0 text-white" />
+                      <Trophy
+                        aria-hidden="true"
+                        className="size-4 shrink-0"
+                        style={{ color: tinta }}
+                      />
                     ) : null}
-                    {/* Sem truncar: "Venda ganha" já cortava no telefone, e
-                        nome de etapa cortado é etapa que ninguém identifica. */}
-                    <span className="font-semibold text-[13px] text-white uppercase leading-tight tracking-wide">
+                    {/* Sem truncar: "Venda gan…" é etapa que ninguém identifica. */}
+                    <span
+                      className="font-bold text-[13px] uppercase leading-tight tracking-wider"
+                      style={{ color: tinta }}
+                    >
                       {etapa.label}
                     </span>
                   </div>
                 </div>
-                <Fio lado="esquerda" />
+                <span
+                  aria-hidden="true"
+                  className="hidden h-px w-5 shrink-0 sm:block"
+                  style={{ background: `color-mix(in oklab, ${cor} 55%, transparent)` }}
+                />
               </div>
 
-              {/* A forma. Some no telefone: com a tela estreita o trapézio fica
-                  raso demais para dizer alguma coisa, e o que sobra — nome,
+              {/* A forma. Some no telefone: com a tela estreita a lâmina fica
+                  rasa demais para dizer alguma coisa, e o que sobra — nome,
                   contagem e queda — já é o funil em texto. */}
-              <div className="col-span-2 hidden h-16 sm:col-span-1 sm:block">
-                <Faixa etapa={etapa} cima={cima} baixo={baixo} cor={cor} />
+              <div className="col-span-2 hidden h-[4.5rem] sm:col-span-1 sm:block">
+                <Lamina etapa={etapa} cima={cima} cor={cor} />
               </div>
 
-              <div className="flex items-center justify-end">
-                <Fio lado="direita" />
-                <div className="flex flex-1 items-center justify-between gap-3 rounded-xl border border-white/15 bg-white/5 px-3.5 py-2">
-                  <span className="font-semibold text-lg text-white tabular-nums">
+              <div className="flex items-center">
+                <span
+                  aria-hidden="true"
+                  className="hidden h-px w-5 shrink-0 sm:block"
+                  style={{ background: `color-mix(in oklab, ${cor} 55%, transparent)` }}
+                />
+                <div
+                  className="flex flex-1 items-center justify-between gap-3 rounded-lg border px-3 py-2"
+                  style={{
+                    borderColor: `color-mix(in oklab, ${cor} 55%, transparent)`,
+                    background: `color-mix(in oklab, ${cor} 9%, transparent)`,
+                  }}
+                >
+                  <span
+                    className="font-bold text-xl leading-none tabular-nums"
+                    style={{ color: tinta }}
+                  >
                     {formatMetric(etapa.value, "integer")}
                   </span>
-                  {/* Duas linhas curtas, e não três informações numa só: na
-                      largura desta coluna "da etapa anterior" quebra no meio e
-                      o número perde o rótulo. */}
+                  {/* Duas linhas curtas, e não tudo numa: nesta largura "da
+                      etapa anterior" quebra no meio e o número perde o rótulo. */}
                   <span className="text-right text-[11px] text-plum-200 leading-tight tabular-nums">
                     <span className="block whitespace-nowrap">{porcento(doTopo)} do topo</span>
                     {queda !== null && queda > 0 ? (

--- a/src/components/charts/funnel-chart.tsx
+++ b/src/components/charts/funnel-chart.tsx
@@ -1,39 +1,41 @@
 import { Trophy } from "lucide-react";
 
 import { LightBlock } from "@/components/brand/light-block";
+import { cn } from "@/lib/cn";
 import { formatMetric } from "@/lib/format";
 import type { FunnelBlock, FunnelStage } from "@/lib/types";
 
 /**
  * O funil comercial, em figura.
  *
- * Lâminas empilhadas, no formato de diagrama de apresentação: cada etapa é uma
- * lâmina própria, com folga entre elas, e a diferença de largura de uma para a
- * outra é a perda. Caixa de rótulo à esquerda, caixa de números à direita, fio
- * ligando as duas à lâmina — o desenho que o comercial reconhece de slide, com
- * a paleta da casa no lugar do arco-íris de banco de imagem.
- *
- * **A aresta de cima de cada lâmina é o número da etapa.** É a única codificação
- * de grandeza. Cada lâmina ainda estreita um pouco sozinha, de um valor fixo e
- * igual para todas — isso é desenho, não dado, e é o que dá o empilhamento em
- * vez de um cone contínuo. O que informa é o degrau **entre** lâminas.
+ * Faixas separadas, cada uma um trapézio: a aresta de cima é o número da etapa,
+ * a de baixo é o da próxima, e o quanto ela estreita é a perda entre as duas.
+ * Onde a forma aperta é onde o processo trava — que é a única coisa que um
+ * funil desenhado faz melhor que a tabela ao lado.
  *
  * **Mora no slab escuro da marca, nos dois temas.** Não é escolha de gosto: uma
- * rampa de um hue só precisa de superfície fixa para ter contraste garantido, e
- * alternar a superfície obrigaria a manter duas rampas validadas em vez de uma.
- * O slab é o mesmo da navegação e da tela de entrada.
+ * rampa de um hue só precisa de uma superfície fixa para ter contraste
+ * garantido, e alternar a superfície obrigaria a manter duas rampas validadas
+ * em vez de uma. O slab é o mesmo da navegação e da tela de entrada, então a
+ * peça mais chamativa do painel continua sendo a marca, e não uma exceção.
  *
- * **Sem tooltip, de propósito.** Etapa, contagem, porcentagem e queda estão
- * todas escritas ao lado da forma; um tooltip repetiria o visível e esconderia
- * o dado de quem navega por teclado.
+ * **Sem tooltip, de propósito.** A regra da casa é que gráfico em HTML tem
+ * camada de hover; a exceção aqui é que não há nada escondido para revelar —
+ * etapa, contagem, porcentagem e queda estão todas escritas ao lado da forma.
+ * Um tooltip repetiria o visível e ainda esconderia o dado de quem navega por
+ * teclado.
+ *
+ * A largura é a única codificação de grandeza. A cor apenas ordena — e o
+ * desfecho, que não é etapa de passagem, sai da rampa e vem com ícone e
+ * rótulo, nunca só com a cor trocada.
  */
 
 /**
  * A rampa, do topo do funil para a base.
  *
  * Validada contra `#2f2535`, que é a superfície onde ela sempre aparece. Sobre
- * fundo escuro quem tem mais volume precisa de mais luz, então a ordem vai do
- * passo mais claro para o mais fechado.
+ * fundo escuro quem tem mais volume precisa de mais luz, não de menos: a
+ * ordem é do passo mais claro para o mais fechado.
  */
 const RAMPA = [
   "var(--qy-funnel-1)",
@@ -57,37 +59,34 @@ function corDaEtapa(indice: number, total: number): string {
 }
 
 /**
- * O passo escuro da rampa não tem contraste para virar texto.
- *
- * Clarear o mesmo hue mantém a caixa visivelmente da cor da lâmina — que é o
- * que amarra rótulo e forma — sem depender de um passo que, em corpo pequeno,
- * ninguém lê.
- */
-function paraTexto(cor: string): string {
-  return `color-mix(in oklab, ${cor} 62%, white)`;
-}
-
-/**
  * Largura da boca, em porcentagem da coluna da figura.
  *
- * Baixa de propósito. Com a boca ocupando a coluna inteira, a primeira lâmina
- * vira uma prancha e as seguintes viram blocos soltos — some a silhueta de
+ * Não é só folga de borda. Com a boca ocupando quase toda a coluna, a primeira
+ * etapa vira uma prancha e as seguintes viram blocos — some a silhueta de
  * funil, que é a única razão de existir um desenho aqui em vez de só a tabela.
  */
-const BOCA = 88;
+const BOCA = 82;
 
 /**
  * Piso de largura da aresta.
  *
- * Etapa zerada continua sendo uma lâmina visível em vez de sumir: "ninguém
- * chega aqui" é informação, e largura zero levaria o rótulo junto. O número ao
- * lado continua dizendo zero — a figura nunca é a fonte do valor.
+ * Etapa zerada continua sendo uma faixa visível em vez de sumir: "ninguém chega
+ * aqui" é informação, e largura zero levaria o rótulo junto. O número ao lado
+ * continua dizendo zero — a figura nunca é a fonte do valor.
  */
-const PISO = 7;
+const PISO = 9;
 
 function largura(valor: number, topo: number): number {
   if (topo <= 0) return PISO;
   return Math.max(PISO, (valor / topo) * BOCA);
+}
+
+function trapezio(cima: number, baixo: number): string {
+  const a = (100 - cima) / 2;
+  const b = (100 + cima) / 2;
+  const c = (100 + baixo) / 2;
+  const d = (100 - baixo) / 2;
+  return `polygon(${a}% 0%, ${b}% 0%, ${c}% 100%, ${d}% 100%)`;
 }
 
 /** Porcentagem em número inteiro: a figura não tem duas casas de precisão. */
@@ -95,32 +94,101 @@ function porcento(fracao: number): string {
   return `${Math.round(fracao * 100)}%`;
 }
 
-function Lamina({ etapa, cima, cor }: { etapa: FunnelStage; cima: number; cor: string }) {
+/**
+ * Altura da tampa arredondada, em pixels.
+ *
+ * O cone é feito de recortes poligonais, e recorte não aceita raio. A boca e a
+ * bica ganham então uma tampa própria — retângulo de raio total na mesma
+ * largura da aresta, encaixado sem costura. É o que tira a quina viva de uma
+ * interface que é arredondada em todo o resto.
+ */
+const TAMPA = 18;
+
+function Faixa({
+  etapa,
+  cima,
+  baixo,
+  cor,
+  primeira,
+  ultima,
+}: {
+  etapa: FunnelStage;
+  cima: number;
+  baixo: number;
+  cor: string;
+  primeira: boolean;
+  ultima: boolean;
+}) {
+  // Horizontal, e não diagonal: a tampa e o corpo são elementos separados, e um
+  // degradê com componente vertical mudaria de tom entre os dois, deixando uma
+  // emenda visível justamente na aresta que deveria ser lisa.
+  const fundo = `linear-gradient(90deg, color-mix(in oklab, ${cor} 92%, white) 0%, ${cor} 58%, color-mix(in oklab, ${cor} 74%, #17111b) 100%)`;
+
   return (
-    <div className="flex h-full items-center justify-center">
-      {/* Raio total, e não canto vivo: a marca é arredondada em tudo — slab de
-          28px na navegação, pílula nos filtros — e um trapézio de quina viva no
-          meio da tela briga com o que está em volta. Aqui a altura da lâmina é
-          56px, então o raio cheio dá justamente os 28px do slab. */}
+    <div
+      aria-hidden="true"
+      className="relative h-full w-full transition-[filter] duration-[var(--duration-base)] ease-[var(--ease-out-soft)] group-hover:brightness-110"
+    >
+      {primeira ? (
+        <div className="absolute inset-x-0 top-0 flex justify-center" style={{ height: TAMPA }}>
+          <div className="h-full rounded-t-full" style={{ width: `${cima}%`, background: fundo }} />
+        </div>
+      ) : null}
+
       <div
-        aria-hidden="true"
-        className="relative h-full rounded-full ring-1 ring-white/10 ring-inset transition-transform duration-[var(--duration-base)] ease-[var(--ease-out-soft)] group-hover:scale-[1.03]"
+        className="absolute inset-x-0"
         style={{
-          width: `${cima}%`,
-          background: `linear-gradient(108deg, color-mix(in oklab, ${cor} 90%, white) 0%, ${cor} 55%, color-mix(in oklab, ${cor} 70%, #17111b) 100%)`,
+          top: primeira ? TAMPA : 0,
+          // Dois pixels de superfície entre faixas, como em toda marca colada
+          // do painel: é o respiro que separa uma etapa da seguinte sem
+          // precisar de contorno, e sem ele o cone vira uma mancha só.
+          bottom: ultima ? TAMPA : 2,
+          clipPath: trapezio(cima, baixo),
+          background: fundo,
         }}
-      >
-        {/* Fio de luz na aresta de cima, discreto. Halo e brilho descendo pela
-            lâmina davam ar de botão lustroso, e ainda lavavam a cor — a rampa
-            perdia a diferença entre um passo e o seguinte. */}
-        <div className="absolute inset-x-4 top-0 h-1/4 rounded-full bg-gradient-to-b from-white/20 to-transparent" />
-        {etapa.outcome === "ganho" ? (
-          <div className="absolute inset-0 grid place-items-center">
-            <Trophy className="size-5 text-plum-900" />
-          </div>
-        ) : null}
-      </div>
+      />
+
+      {ultima ? (
+        <div className="absolute inset-x-0 bottom-0 flex justify-center" style={{ height: TAMPA }}>
+          <div
+            className="h-full rounded-b-full"
+            style={{ width: `${baixo}%`, background: fundo }}
+          />
+        </div>
+      ) : null}
+
+      {/* Fio de luz só na boca. Brilho em toda faixa lavava a cor, e a rampa
+          perdia a diferença entre um passo e o seguinte. */}
+      {primeira ? (
+        <div className="absolute inset-x-0 top-0 flex justify-center">
+          <div
+            className="h-2 rounded-t-full bg-gradient-to-b from-white/25 to-transparent"
+            style={{ width: `${cima}%` }}
+          />
+        </div>
+      ) : null}
+
+      {etapa.outcome === "ganho" ? (
+        <div className="absolute inset-0 grid place-items-center">
+          <Trophy className="size-5 text-plum-900" />
+        </div>
+      ) : null}
     </div>
+  );
+}
+
+/** Fio que liga a caixa de texto à faixa, como num diagrama de apresentação. */
+function Fio({ lado }: { lado: "esquerda" | "direita" }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "hidden h-px w-4 shrink-0 sm:block",
+        lado === "esquerda"
+          ? "bg-gradient-to-r from-transparent to-white/25"
+          : "bg-gradient-to-l from-transparent to-white/25",
+      )}
+    />
   );
 }
 
@@ -131,7 +199,7 @@ export function FunnelChart({ block }: { block: FunnelBlock }) {
   const topo = etapas[0]?.value ?? 0;
 
   return (
-    <figure className="qy-fade relative overflow-hidden rounded-[var(--radius-slab)] bg-plum-800 px-4 py-6 text-white sm:px-7 sm:py-9">
+    <figure className="qy-fade relative overflow-hidden rounded-[var(--radius-slab)] bg-plum-800 px-4 py-6 text-white sm:px-6 sm:py-8">
       <LightBlock className="opacity-70" />
 
       <figcaption className="sr-only">
@@ -139,85 +207,73 @@ export function FunnelChart({ block }: { block: FunnelBlock }) {
         {block.description ? `. ${block.description}` : ""}
       </figcaption>
 
-      <ol className="relative space-y-0.5">
+      <ol className="relative">
         {etapas.map((etapa, i) => {
+          const proxima = etapas[i + 1];
+          const primeira = i === 0;
+          const ultima = proxima === undefined;
           const cima = largura(etapa.value, topo);
+          // Na última faixa não há próxima etapa para medir: o estreitamento é
+          // desenho, não dado — é o que fecha a peça como bica em vez de deixar
+          // um tarugo cortado reto no fim do cone.
+          const baixo = ultima ? cima * 0.78 : largura(proxima.value, topo);
           const doTopo = topo === 0 ? 0 : etapa.value / topo;
           const anterior = etapas[i - 1]?.value;
           const queda =
             anterior === undefined || anterior === 0 ? null : 1 - etapa.value / anterior;
           const cor =
             etapa.outcome === "ganho" ? "var(--qy-funnel-ganho)" : corDaEtapa(i, etapas.length);
-          const tinta = paraTexto(cor);
 
           return (
             <li
               key={etapa.label}
-              className="group grid grid-cols-2 items-center gap-x-2 gap-y-1 sm:grid-cols-[minmax(0,0.9fr)_minmax(0,2.2fr)_minmax(0,0.9fr)] sm:gap-x-0"
+              className="group grid grid-cols-2 items-center gap-x-3 gap-y-1 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)_minmax(0,1fr)] sm:gap-x-4"
             >
-              {/* Caixa de rótulo na cor da lâmina, com o fio ligando à forma —
-                  o texto fica fora do trapézio, onde nome comprido não cabe e o
-                  contraste mudaria a cada passo da rampa. */}
+              {/* Caixa de rótulo com filete da cor da faixa: é o que amarra o
+                  texto à forma sem escrever nada por cima do trapézio, onde
+                  nome comprido não cabe e o contraste muda a cada passo. */}
               <div className="flex items-center">
                 <div
-                  className="min-w-0 flex-1 rounded-full border px-4 py-2.5"
-                  style={{
-                    borderColor: `color-mix(in oklab, ${cor} 55%, transparent)`,
-                    background: `color-mix(in oklab, ${cor} 9%, transparent)`,
-                  }}
+                  className="min-w-0 flex-1 rounded-xl border border-white/15 bg-white/5 py-2 pr-3 pl-3"
+                  style={{ borderLeft: `3px solid ${cor}` }}
                 >
                   <div className="flex items-center gap-1.5">
                     {etapa.outcome === "ganho" ? (
-                      <Trophy
-                        aria-hidden="true"
-                        className="size-4 shrink-0"
-                        style={{ color: tinta }}
-                      />
+                      <Trophy aria-hidden="true" className="size-3.5 shrink-0 text-white" />
                     ) : null}
-                    {/* Sem truncar: "Venda gan…" é etapa que ninguém identifica. */}
-                    <span
-                      className="font-bold text-[13px] uppercase leading-tight tracking-wider"
-                      style={{ color: tinta }}
-                    >
+                    {/* Sem truncar: "Venda ganha" já cortava no telefone, e
+                        nome de etapa cortado é etapa que ninguém identifica. */}
+                    <span className="font-semibold text-[13px] text-white uppercase leading-tight tracking-wide">
                       {etapa.label}
                     </span>
                   </div>
                 </div>
-                <span
-                  aria-hidden="true"
-                  className="hidden h-px w-5 shrink-0 sm:block"
-                  style={{ background: `color-mix(in oklab, ${cor} 55%, transparent)` }}
-                />
+                <Fio lado="esquerda" />
               </div>
 
-              {/* A forma. Some no telefone: com a tela estreita a lâmina fica
-                  rasa demais para dizer alguma coisa, e o que sobra — nome,
+              {/* A forma. Some no telefone: com a tela estreita o trapézio fica
+                  raso demais para dizer alguma coisa, e o que sobra — nome,
                   contagem e queda — já é o funil em texto. */}
-              <div className="col-span-2 hidden h-[3.75rem] py-px sm:col-span-1 sm:block">
-                <Lamina etapa={etapa} cima={cima} cor={cor} />
+              <div className="col-span-2 hidden h-16 sm:col-span-1 sm:block">
+                <Faixa
+                  etapa={etapa}
+                  cima={cima}
+                  baixo={baixo}
+                  cor={cor}
+                  primeira={primeira}
+                  ultima={ultima}
+                />
               </div>
 
-              <div className="flex items-center">
-                <span
-                  aria-hidden="true"
-                  className="hidden h-px w-5 shrink-0 sm:block"
-                  style={{ background: `color-mix(in oklab, ${cor} 55%, transparent)` }}
-                />
-                <div
-                  className="flex flex-1 items-center justify-between gap-3 rounded-full border px-4 py-2"
-                  style={{
-                    borderColor: `color-mix(in oklab, ${cor} 55%, transparent)`,
-                    background: `color-mix(in oklab, ${cor} 9%, transparent)`,
-                  }}
-                >
-                  <span
-                    className="font-bold text-xl leading-none tabular-nums"
-                    style={{ color: tinta }}
-                  >
+              <div className="flex items-center justify-end">
+                <Fio lado="direita" />
+                <div className="flex flex-1 items-center justify-between gap-3 rounded-xl border border-white/15 bg-white/5 px-3.5 py-2">
+                  <span className="font-semibold text-lg text-white tabular-nums">
                     {formatMetric(etapa.value, "integer")}
                   </span>
-                  {/* Duas linhas curtas, e não tudo numa: nesta largura "da
-                      etapa anterior" quebra no meio e o número perde o rótulo. */}
+                  {/* Duas linhas curtas, e não três informações numa só: na
+                      largura desta coluna "da etapa anterior" quebra no meio e
+                      o número perde o rótulo. */}
                   <span className="text-right text-[11px] text-plum-200 leading-tight tabular-nums">
                     <span className="block whitespace-nowrap">{porcento(doTopo)} do topo</span>
                     {queda !== null && queda > 0 ? (

--- a/src/components/charts/funnel-chart.tsx
+++ b/src/components/charts/funnel-chart.tsx
@@ -67,8 +67,14 @@ function paraTexto(cor: string): string {
   return `color-mix(in oklab, ${cor} 62%, white)`;
 }
 
-/** A boca do funil não encosta na borda do slab. */
-const BOCA = 96;
+/**
+ * Largura da boca, em porcentagem da coluna da figura.
+ *
+ * Baixa de propósito. Com a boca ocupando a coluna inteira, a primeira lâmina
+ * vira uma prancha e as seguintes viram blocos soltos — some a silhueta de
+ * funil, que é a única razão de existir um desenho aqui em vez de só a tabela.
+ */
+const BOCA = 88;
 
 /**
  * Piso de largura da aresta.
@@ -79,26 +85,9 @@ const BOCA = 96;
  */
 const PISO = 7;
 
-/**
- * O quanto cada lâmina estreita sozinha, de cima para baixo.
- *
- * Constante e igual para todas: é o que faz a peça parecer empilhada em vez de
- * um cone liso, e por ser a mesma em todas não mexe na proporção entre etapas.
- */
-const CHANFRO = 0.84;
-
 function largura(valor: number, topo: number): number {
   if (topo <= 0) return PISO;
   return Math.max(PISO, (valor / topo) * BOCA);
-}
-
-function lamina(cima: number): string {
-  const baixo = cima * CHANFRO;
-  const a = (100 - cima) / 2;
-  const b = (100 + cima) / 2;
-  const c = (100 + baixo) / 2;
-  const d = (100 - baixo) / 2;
-  return `polygon(${a}% 0%, ${b}% 0%, ${c}% 100%, ${d}% 100%)`;
 }
 
 /** Porcentagem em número inteiro: a figura não tem duas casas de precisão. */
@@ -107,34 +96,30 @@ function porcento(fracao: number): string {
 }
 
 function Lamina({ etapa, cima, cor }: { etapa: FunnelStage; cima: number; cor: string }) {
-  const recorte = lamina(cima);
-
   return (
-    <div
-      aria-hidden="true"
-      className="relative h-full w-full transition-transform duration-[var(--duration-base)] ease-[var(--ease-out-soft)] group-hover:scale-[1.03]"
-    >
+    <div className="flex h-full items-center justify-center">
+      {/* Raio total, e não canto vivo: a marca é arredondada em tudo — slab de
+          28px na navegação, pílula nos filtros — e um trapézio de quina viva no
+          meio da tela briga com o que está em volta. Aqui a altura da lâmina é
+          56px, então o raio cheio dá justamente os 28px do slab. */}
       <div
-        className="absolute inset-0"
+        aria-hidden="true"
+        className="relative h-full rounded-full ring-1 ring-white/10 ring-inset transition-transform duration-[var(--duration-base)] ease-[var(--ease-out-soft)] group-hover:scale-[1.03]"
         style={{
-          clipPath: recorte,
-          // Degradê dentro do mesmo passo, na diagonal: dá volume à lâmina sem
-          // introduzir uma segunda cor, que quebraria a leitura de rampa.
-          background: `linear-gradient(105deg, color-mix(in oklab, ${cor} 82%, white) 0%, ${cor} 46%, color-mix(in oklab, ${cor} 68%, #17111b) 100%)`,
+          width: `${cima}%`,
+          background: `linear-gradient(108deg, color-mix(in oklab, ${cor} 90%, white) 0%, ${cor} 55%, color-mix(in oklab, ${cor} 70%, #17111b) 100%)`,
         }}
-      />
-      <div
-        className="absolute inset-0 opacity-60"
-        style={{
-          clipPath: recorte,
-          background: "linear-gradient(180deg, rgba(255,255,255,0.5) 0%, transparent 30%)",
-        }}
-      />
-      {etapa.outcome === "ganho" ? (
-        <div className="absolute inset-0 grid place-items-center" style={{ clipPath: recorte }}>
-          <Trophy className="size-5 text-plum-900" />
-        </div>
-      ) : null}
+      >
+        {/* Fio de luz na aresta de cima, discreto. Halo e brilho descendo pela
+            lâmina davam ar de botão lustroso, e ainda lavavam a cor — a rampa
+            perdia a diferença entre um passo e o seguinte. */}
+        <div className="absolute inset-x-4 top-0 h-1/4 rounded-full bg-gradient-to-b from-white/20 to-transparent" />
+        {etapa.outcome === "ganho" ? (
+          <div className="absolute inset-0 grid place-items-center">
+            <Trophy className="size-5 text-plum-900" />
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -154,7 +139,7 @@ export function FunnelChart({ block }: { block: FunnelBlock }) {
         {block.description ? `. ${block.description}` : ""}
       </figcaption>
 
-      <ol className="relative space-y-2.5">
+      <ol className="relative space-y-0.5">
         {etapas.map((etapa, i) => {
           const cima = largura(etapa.value, topo);
           const doTopo = topo === 0 ? 0 : etapa.value / topo;
@@ -168,14 +153,14 @@ export function FunnelChart({ block }: { block: FunnelBlock }) {
           return (
             <li
               key={etapa.label}
-              className="group grid grid-cols-2 items-center gap-x-2 gap-y-1 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.7fr)_minmax(0,1fr)] sm:gap-x-0"
+              className="group grid grid-cols-2 items-center gap-x-2 gap-y-1 sm:grid-cols-[minmax(0,0.9fr)_minmax(0,2.2fr)_minmax(0,0.9fr)] sm:gap-x-0"
             >
               {/* Caixa de rótulo na cor da lâmina, com o fio ligando à forma —
                   o texto fica fora do trapézio, onde nome comprido não cabe e o
                   contraste mudaria a cada passo da rampa. */}
               <div className="flex items-center">
                 <div
-                  className="min-w-0 flex-1 rounded-lg border px-3 py-2.5"
+                  className="min-w-0 flex-1 rounded-full border px-4 py-2.5"
                   style={{
                     borderColor: `color-mix(in oklab, ${cor} 55%, transparent)`,
                     background: `color-mix(in oklab, ${cor} 9%, transparent)`,
@@ -208,7 +193,7 @@ export function FunnelChart({ block }: { block: FunnelBlock }) {
               {/* A forma. Some no telefone: com a tela estreita a lâmina fica
                   rasa demais para dizer alguma coisa, e o que sobra — nome,
                   contagem e queda — já é o funil em texto. */}
-              <div className="col-span-2 hidden h-[4.5rem] sm:col-span-1 sm:block">
+              <div className="col-span-2 hidden h-[3.75rem] py-px sm:col-span-1 sm:block">
                 <Lamina etapa={etapa} cima={cima} cor={cor} />
               </div>
 
@@ -219,7 +204,7 @@ export function FunnelChart({ block }: { block: FunnelBlock }) {
                   style={{ background: `color-mix(in oklab, ${cor} 55%, transparent)` }}
                 />
                 <div
-                  className="flex flex-1 items-center justify-between gap-3 rounded-lg border px-3 py-2"
+                  className="flex flex-1 items-center justify-between gap-3 rounded-full border px-4 py-2"
                   style={{
                     borderColor: `color-mix(in oklab, ${cor} 55%, transparent)`,
                     background: `color-mix(in oklab, ${cor} 9%, transparent)`,

--- a/src/components/charts/funnel-chart.tsx
+++ b/src/components/charts/funnel-chart.tsx
@@ -1,0 +1,223 @@
+import { Trophy } from "lucide-react";
+
+import { cn } from "@/lib/cn";
+import { formatMetric } from "@/lib/format";
+import type { FunnelBlock, FunnelStage } from "@/lib/types";
+
+/**
+ * O funil comercial, em figura.
+ *
+ * Uma pilha de trapézios: a largura de cada aresta é o número daquela etapa, e
+ * a inclinação entre duas arestas é a perda entre elas. Ler o estrangulamento
+ * vira ver onde a figura aperta — que é a única coisa que um funil desenhado
+ * faz melhor que a tabela ao lado.
+ *
+ * **Sem tooltip, de propósito.** A regra da casa é que gráfico em HTML tem
+ * camada de hover; a exceção aqui é que não há nada escondido para revelar —
+ * etapa, contagem, porcentagem e queda estão todas escritas na tela, ao lado
+ * da forma. Um tooltip repetiria o que já está visível e ainda esconderia o
+ * dado de quem navega por teclado.
+ *
+ * A largura é a única codificação de grandeza. A cor apenas ordena, na rampa
+ * de um hue só — e o desfecho, que não é etapa de passagem, sai da rampa e vem
+ * com ícone e rótulo, nunca só com a cor trocada.
+ */
+
+/** Passos da rampa ordinal, do topo do funil para a base. */
+const RAMPA = [
+  "var(--qy-funnel-1)",
+  "var(--qy-funnel-2)",
+  "var(--qy-funnel-3)",
+  "var(--qy-funnel-4)",
+  "var(--qy-funnel-5)",
+];
+
+/**
+ * Uma cor da rampa para cada etapa, distribuídas de ponta a ponta.
+ *
+ * Com três etapas o funil usa o primeiro, o do meio e o último passo — e não
+ * os três primeiros. Assim a diferença entre a boca e o fim é sempre a mesma,
+ * independentemente de quantas etapas a clínica tenha criado no CRM.
+ */
+function corDaEtapa(indice: number, total: number): string {
+  if (total <= 1) return RAMPA[0];
+  const posicao = Math.round((indice / (total - 1)) * (RAMPA.length - 1));
+  return RAMPA[posicao];
+}
+
+/**
+ * Largura da aresta, em porcentagem da boca do funil.
+ *
+ * O piso de 3% existe para etapa zerada continuar sendo uma linha visível em
+ * vez de sumir: "ninguém chega aqui" é informação, e uma forma de largura zero
+ * some junto com a linha inteira, levando o rótulo embora. O número ao lado
+ * continua dizendo zero — a figura nunca é a fonte do valor.
+ */
+const PISO = 3;
+
+/**
+ * A boca do funil não encosta na borda do cartão.
+ *
+ * Sem folga a primeira faixa termina rente ao corte da superfície e passa a
+ * ler como forma cortada, e não como forma larga — o desenho parece um erro de
+ * layout justamente na etapa mais importante.
+ */
+const BOCA = 92;
+
+function largura(valor: number, topo: number): number {
+  if (topo <= 0) return PISO;
+  return Math.max(PISO, (valor / topo) * BOCA);
+}
+
+/**
+ * Porcentagem em número inteiro.
+ *
+ * O formatador da casa leva duas casas, que é o certo para uma taxa de
+ * conversão comparada mês a mês. Aqui não: "−59,22%" ao lado de uma forma
+ * geométrica finge uma precisão que a figura não tem, e o que se lê é a ordem
+ * de grandeza da queda.
+ */
+function porcento(fracao: number): string {
+  return `${Math.round(fracao * 100)}%`;
+}
+
+function trapezio(cima: number, baixo: number): string {
+  const a = (100 - cima) / 2;
+  const b = (100 + cima) / 2;
+  const c = (100 + baixo) / 2;
+  const d = (100 - baixo) / 2;
+  return `polygon(${a}% 0%, ${b}% 0%, ${c}% 100%, ${d}% 100%)`;
+}
+
+function Faixa({
+  etapa,
+  cima,
+  baixo,
+  cor,
+}: {
+  etapa: FunnelStage;
+  cima: number;
+  baixo: number;
+  cor: string;
+}) {
+  return (
+    <div
+      aria-hidden="true"
+      className="relative h-full w-full transition-transform duration-[var(--duration-base)] ease-[var(--ease-out-soft)] group-hover:scale-y-[1.04]"
+    >
+      <div
+        className="absolute inset-0"
+        style={{ clipPath: trapezio(cima, baixo), background: cor }}
+      />
+      {/* Recorte de luz do brandbook, o mesmo da navegação: dá volume à forma
+          sem inventar uma segunda cor. */}
+      <div
+        className="absolute inset-0 opacity-[0.18] mix-blend-overlay"
+        style={{
+          clipPath: trapezio(cima, baixo),
+          background: "linear-gradient(160deg, #ffffff 0%, transparent 55%)",
+        }}
+      />
+      {etapa.outcome === "ganho" ? (
+        <div
+          className="absolute inset-0 grid place-items-center"
+          style={{ clipPath: trapezio(cima, baixo) }}
+        >
+          <Trophy className="size-4 text-white/90" />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function FunnelChart({ block }: { block: FunnelBlock }) {
+  const etapas = block.stages;
+  if (etapas.length === 0) return null;
+
+  const topo = etapas[0]?.value ?? 0;
+
+  return (
+    <figure className="qy-fade">
+      <figcaption className="sr-only">
+        {block.title}
+        {block.description ? `. ${block.description}` : ""}
+      </figcaption>
+
+      <ol className="space-y-0">
+        {etapas.map((etapa, i) => {
+          const proxima = etapas[i + 1];
+          const cima = largura(etapa.value, topo);
+          const baixo = largura(proxima?.value ?? etapa.value, topo);
+          const doTopo = topo === 0 ? 0 : etapa.value / topo;
+          // Queda em relação à etapa anterior, que é a leitura que interessa:
+          // "de Qualificação para Negociação some metade".
+          const anterior = etapas[i - 1]?.value;
+          const queda =
+            anterior === undefined || anterior === 0 ? null : 1 - etapa.value / anterior;
+
+          return (
+            <li
+              key={etapa.label}
+              className="group grid grid-cols-[1fr_auto] items-stretch gap-3 sm:grid-cols-[minmax(0,11rem)_1fr_auto] sm:gap-4"
+            >
+              {/* Rótulo fora da forma: nome de etapa longo não cabe dentro de
+                  um trapézio estreito, e texto sobre a rampa perderia contraste
+                  justamente nos passos claros. */}
+              <div className="flex flex-col justify-center py-1 sm:py-0">
+                <div className="flex items-center gap-1.5">
+                  {etapa.outcome === "ganho" ? (
+                    <Trophy aria-hidden="true" className="size-3.5 shrink-0 text-positive" />
+                  ) : null}
+                  <span
+                    className={cn(
+                      "font-medium text-sm",
+                      etapa.outcome === "ganho" ? "text-positive" : "text-ink",
+                    )}
+                  >
+                    {etapa.label}
+                  </span>
+                </div>
+                {queda !== null && queda > 0 ? (
+                  <span className="text-[11px] text-ink-muted tabular-nums">
+                    −{porcento(queda)} da etapa anterior
+                  </span>
+                ) : null}
+              </div>
+
+              {/* A forma. Some no telefone: com a tela estreita o trapézio fica
+                  raso demais para dizer alguma coisa, e o que sobra — nome,
+                  contagem e queda — já é o funil em texto. */}
+              <div className="hidden h-16 py-[2px] sm:block">
+                <Faixa
+                  etapa={etapa}
+                  cima={cima}
+                  baixo={baixo}
+                  cor={
+                    etapa.outcome === "ganho"
+                      ? "var(--color-positive)"
+                      : corDaEtapa(i, etapas.length)
+                  }
+                />
+              </div>
+
+              <div className="flex flex-col items-end justify-center py-1 sm:py-0">
+                <span className="font-semibold text-base text-ink tabular-nums">
+                  {formatMetric(etapa.value, "integer")}
+                </span>
+                <span className="text-[11px] text-ink-muted tabular-nums">
+                  {porcento(doTopo)} do topo
+                </span>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      {block.caveat ? (
+        <p className="mt-4 border-line border-t pt-3 text-[11px] text-ink-muted leading-relaxed">
+          {block.caveat}
+        </p>
+      ) : null}
+    </figure>
+  );
+}

--- a/src/components/report/channel-view.tsx
+++ b/src/components/report/channel-view.tsx
@@ -1,3 +1,4 @@
+import { FunnelChart } from "@/components/charts/funnel-chart";
 import { TrendSmallMultiples } from "@/components/charts/lazy";
 import { Notices } from "@/components/layout/notices";
 import { PageHeader } from "@/components/layout/page-header";
@@ -51,6 +52,25 @@ export function ChannelView({
           <StatTile key={kpi.key} kpi={kpi} />
         ))}
       </section>
+
+      {/* Antes do gráfico de evolução, e não depois das tabelas: numa tela de
+          vendas a primeira pergunta é onde o processo aperta, não como o mês
+          andou. */}
+      {report.funnel && report.funnel.stages.length > 0 ? (
+        <Card className="qy-rise">
+          <CardHeader>
+            <div>
+              <CardTitle>{report.funnel.title}</CardTitle>
+              {report.funnel.description ? (
+                <CardDescription>{report.funnel.description}</CardDescription>
+              ) : null}
+            </div>
+          </CardHeader>
+          <CardContent>
+            <FunnelChart block={report.funnel} />
+          </CardContent>
+        </Card>
+      ) : null}
 
       <Card className="qy-rise">
         <CardHeader>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -96,6 +96,47 @@ export interface TableBlock {
 }
 
 /**
+ * Uma etapa do funil comercial, já com o acumulado calculado.
+ *
+ * `value` é **quantos chegaram até aqui**, não quantos estão parados aqui. São
+ * perguntas diferentes: um negócio em Negociação já passou por Qualificação, e
+ * desenhar a ocupação como se fosse fluxo faria a etapa do meio parecer um
+ * gargalo que não existe.
+ */
+export interface FunnelStage {
+  label: string;
+  /** Negócios que chegaram a esta etapa ou passaram dela. */
+  value: number;
+  /** Soma do valor dos negócios contados, quando o CRM tem esse campo. */
+  amount?: number;
+  /**
+   * Etapa de desfecho, e não de passagem.
+   *
+   * O ganho encerra o funil e por isso não usa a rampa das demais: é outra
+   * categoria de coisa, e a cor sozinha não diz isso — vem com ícone e rótulo.
+   */
+  outcome?: "ganho";
+}
+
+/**
+ * O funil comercial em forma de figura.
+ *
+ * Vive ao lado da tabela, não no lugar dela: a figura mostra o estrangulamento
+ * de relance, a tabela é a versão em texto que sobrevive a leitor de tela, a
+ * impressão em preto e branco e ao "me manda esse número".
+ */
+export interface FunnelBlock {
+  title: string;
+  description?: string;
+  stages: FunnelStage[];
+  /**
+   * O que a figura não consegue mostrar, dito antes de alguém tirar a conclusão
+   * errada — por exemplo, que o CRM só guarda a etapa atual do negócio.
+   */
+  caveat?: string;
+}
+
+/**
  * Uma peça de conteúdo com a arte e alguns números — anúncio ou publicação.
  *
  * É modelo de tela, não de domínio: cada conector calcula as métricas que
@@ -206,6 +247,8 @@ export interface ChannelReport {
   /** Período real dos dados, quando difere do intervalo pedido. */
   periodLabel?: string;
   tables: TableBlock[];
+  /** O funil comercial em figura, quando o canal tem etapas ordenadas. */
+  funnel?: FunnelBlock;
   /** Peças com a arte, quando a origem fornece: anúncios ou publicações. */
   creatives?: ContentCard[];
   /**

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -810,6 +810,7 @@ export function mockVendas(range: DateRange, fetchedAt = NOW): ChannelReport {
         label: "Perdas recuperáveis",
         value: Math.round((leads - vendas) * 0.34 * 0.58),
         format: "integer",
+        semComparacao: true,
         hint: "Negócios perdidos por preço, tempo ou área de cobertura — os motivos que voltam quando o orçamento, a agenda ou a cobertura mudam. Estão detalhados na tabela de motivos.",
       },
     ],
@@ -818,6 +819,41 @@ export function mockVendas(range: DateRange, fetchedAt = NOW): ChannelReport {
       { key: "receita", label: "Receita", format: "currency", slot: 5 },
       { key: "vendas", label: "Vendas", format: "integer", slot: 2 },
     ],
+    funnel: (() => {
+      const perdidos = Math.round((leads - vendas) * 0.34);
+      const abertos = leads - vendas - perdidos;
+      const primeiro = Math.round(abertos * 0.52);
+      const avaliacao = Math.round(abertos * 0.31);
+      // Acumulado, como no conector: cada etapa soma quem está nela e quem já
+      // passou. A boca do funil é todo mundo que entrou no período.
+      const negociacao = abertos - primeiro - avaliacao + vendas;
+      return {
+        title: "Do primeiro contato ao pagamento",
+        description:
+          "Quantos negócios do período chegaram a cada etapa — não quantos estão parados nela. A largura é a contagem; onde a figura aperta é onde o processo trava.",
+        caveat:
+          "Negócio perdido conta apenas na primeira etapa: o Kommo guarda só a etapa atual do negócio, então não dá para saber em que ponto do funil ele foi perdido. Os motivos estão na tabela de perdas.",
+        stages: [
+          { label: "Novo lead", value: leads, amount: Math.round(leads * 1_620 * 100) / 100 },
+          {
+            label: "Qualificação",
+            value: avaliacao + negociacao,
+            amount: Math.round((avaliacao + negociacao) * 1_620 * 100) / 100,
+          },
+          {
+            label: "Negociação",
+            value: negociacao,
+            amount: Math.round(negociacao * 1_620 * 100) / 100,
+          },
+          {
+            label: "Venda ganha",
+            value: vendas,
+            amount: receita,
+            outcome: "ganho" as const,
+          },
+        ],
+      };
+    })(),
     tables: [
       {
         title: "Negócios por etapa",

--- a/src/mocks/reports.ts
+++ b/src/mocks/reports.ts
@@ -802,9 +802,16 @@ export function mockVendas(range: DateRange, fetchedAt = NOW): ChannelReport {
         previousValue: 7.1,
         format: "decimal",
         lowerIsBetter: true,
-        hint: "Dias entre a criação do negócio e o fechamento, na média dos que fecharam.",
+        hint: "Dias entre a criação do negócio e a etapa de venda ganha, que é quando o pagamento entra. Média dos que fecharam no período.",
       },
       { key: "emAberto", label: "Em aberto", value: Math.round(leads * 0.34), format: "integer" },
+      {
+        key: "recuperaveis",
+        label: "Perdas recuperáveis",
+        value: Math.round((leads - vendas) * 0.34 * 0.58),
+        format: "integer",
+        hint: "Negócios perdidos por preço, tempo ou área de cobertura — os motivos que voltam quando o orçamento, a agenda ou a cobertura mudam. Estão detalhados na tabela de motivos.",
+      },
     ],
     series,
     seriesDefs: [
@@ -831,9 +838,9 @@ export function mockVendas(range: DateRange, fetchedAt = NOW): ChannelReport {
           const primeiro = Math.round(abertos * 0.52);
           const avaliacao = Math.round(abertos * 0.31);
           return [
-            ["Primeiro contato", primeiro],
-            ["Avaliação agendada", avaliacao],
-            ["Proposta enviada", abertos - primeiro - avaliacao],
+            ["Novo lead", primeiro],
+            ["Qualificação", avaliacao],
+            ["Negociação", abertos - primeiro - avaliacao],
             ["Venda ganha", vendas],
             ["Perdido", perdidos],
           ].map(([etapa, negocios]) => ({
@@ -841,6 +848,39 @@ export function mockVendas(range: DateRange, fetchedAt = NOW): ChannelReport {
             negocios: negocios as number,
             valor: Math.round((negocios as number) * 1_620 * 100) / 100,
           }));
+        })(),
+      },
+      {
+        title: "Motivos de perda",
+        description:
+          "Por que os negócios do período não fecharam. Preço, tempo e área de cobertura entram como recuperáveis — são as perdas que voltam quando o orçamento, a agenda ou a cobertura mudam.",
+        columns: [
+          { key: "motivo", label: "Motivo", align: "left" },
+          { key: "situacao", label: "Situação", align: "left" },
+          { key: "negocios", label: "Negócios", format: "integer", align: "right" },
+          { key: "valor", label: "Valor", format: "currency", align: "right" },
+        ],
+        // As fatias somam 1 sobre os perdidos do funil: a tabela de motivos e a
+        // linha "Perdido" precisam fechar, ou a demonstração ensina a
+        // desconfiar do painel.
+        rows: (() => {
+          const perdidos = Math.round((leads - vendas) * 0.34);
+          return [
+            ["Preço fora do orçamento", "Recuperável", 0.26],
+            ["Vai pensar / precisa de tempo", "Recuperável", 0.19],
+            ["Fora da Área de Cobertura", "Recuperável", 0.13],
+            ["Não respondeu após múltiplos contatos", "Arquivar", 0.22],
+            ["Preferiu concorrente ou outra solução", "Arquivar", 0.12],
+            ["Sem motivo registrado", "Arquivar", 0.08],
+          ].map(([motivo, situacao, fatia]) => {
+            const n = Math.round(perdidos * (fatia as number));
+            return {
+              motivo: motivo as string,
+              situacao: situacao as string,
+              negocios: n,
+              valor: Math.round(n * 1_620 * 100) / 100,
+            };
+          });
         })(),
       },
       {

--- a/src/server/connectors/kommo.ts
+++ b/src/server/connectors/kommo.ts
@@ -2,7 +2,15 @@ import "server-only";
 
 import { avisoOperacao } from "@/lib/avisos";
 import { eachDay } from "@/lib/date-range";
-import type { ChannelReport, DateRange, Notice, SeriesPoint, TableBlock } from "@/lib/types";
+import type {
+  ChannelReport,
+  DateRange,
+  FunnelBlock,
+  FunnelStage,
+  Notice,
+  SeriesPoint,
+  TableBlock,
+} from "@/lib/types";
 import { mockVendas } from "@/mocks/reports";
 import { getCredentials, getEnv, isForceMock } from "@/server/env";
 import { descreverFalha, httpJson } from "@/server/lib/http";
@@ -444,6 +452,72 @@ function montarPerdas(perdidos: LeadDoKommo[]): TableBlock {
   };
 }
 
+/**
+ * O funil em figura: quantos **chegaram** a cada etapa.
+ *
+ * A tabela ao lado conta ocupação — quantos estão parados em cada etapa agora.
+ * Desenhar aquilo como funil seria errado: um negócio em Negociação já passou
+ * por Qualificação, e a etapa do meio pareceria um gargalo que não existe. Aqui
+ * cada etapa soma quem está nela e quem já foi adiante.
+ *
+ * **O negócio perdido conta só na boca do funil.** O Kommo guarda apenas a
+ * etapa atual, e a etapa atual de um perdido é "perdido" — quem morreu em
+ * Negociação não deixa rastro de onde estava. Creditá-lo à última etapa
+ * conhecida seria inventar; contá-lo só na entrada subestima o meio do funil, e
+ * é o erro que dá para admitir em voz alta. A ressalva vai junto da figura.
+ */
+function montarFunilVisual(
+  leads: LeadDoKommo[],
+  etapas: EtapaDoFunil[],
+  ganhos: number,
+): FunnelBlock | undefined {
+  if (etapas.length === 0) return undefined;
+
+  const posicao = new Map(etapas.map((etapa, i) => [etapa.id, i]));
+
+  // Quantos chegaram a cada etapa, e o valor que veio junto.
+  const chegaram = etapas.map(() => ({ negocios: 0, valor: 0 }));
+  let valorGanho = 0;
+
+  for (const lead of leads) {
+    const valor = lead.price ?? 0;
+    // Ganho passou por tudo. Perdido, e etapa que não está no funil, contam só
+    // na entrada — é o que dá para afirmar sem inventar.
+    const ate =
+      lead.status_id === GANHO ? etapas.length - 1 : (posicao.get(lead.status_id ?? 0) ?? 0);
+    if (lead.status_id === GANHO) valorGanho += valor;
+
+    for (let i = 0; i <= ate; i++) {
+      chegaram[i].negocios += 1;
+      chegaram[i].valor += valor;
+    }
+  }
+
+  const stages: FunnelStage[] = etapas.map((etapa, i) => ({
+    label: etapa.nome,
+    value: chegaram[i].negocios,
+    amount: Math.round(chegaram[i].valor * 100) / 100,
+  }));
+
+  // O desfecho fecha a figura. Sem ele o funil termina numa etapa de passagem,
+  // e a tela de vendas não mostra a venda.
+  stages.push({
+    label: "Venda ganha",
+    value: ganhos,
+    amount: Math.round(valorGanho * 100) / 100,
+    outcome: "ganho",
+  });
+
+  return {
+    title: "Do primeiro contato ao pagamento",
+    description:
+      "Quantos negócios do período chegaram a cada etapa — não quantos estão parados nela. A largura é a contagem; onde a figura aperta é onde o processo trava.",
+    caveat:
+      "Negócio perdido conta apenas na primeira etapa: o Kommo guarda só a etapa atual do negócio, então não dá para saber em que ponto do funil ele foi perdido. Os motivos estão na tabela de perdas.",
+    stages,
+  };
+}
+
 export async function fetchVendasReport(range: DateRange): Promise<ChannelReport> {
   const forceMock = isForceMock();
 
@@ -606,8 +680,11 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
           label: "Perdas recuperáveis",
           value: recuperaveis.length,
           format: "integer",
-          // Menos é melhor no total de perdas, mas não aqui: esta é a fatia
-          // das perdas que dá para retomar, e ela crescer não é piora.
+          semComparacao: true,
+          // Sem comparação de propósito: este número não tem lado bom. Subir
+          // pode ser "perdemos mais" ou "perdemos mais gente que volta", e a
+          // seta pintaria de verde ou de vermelho uma das duas sem saber qual.
+          // É uma fila de trabalho do mês, não um placar.
           hint: "Negócios perdidos por preço, tempo ou área de cobertura — os motivos que voltam quando o orçamento, a agenda ou a cobertura mudam. Estão detalhados na tabela de motivos.",
         },
       ],
@@ -616,6 +693,7 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
         { key: "receita", label: "Receita", format: "currency", slot: 5 },
         { key: "vendas", label: "Vendas", format: "integer", slot: 2 },
       ],
+      funnel: montarFunilVisual(criados, etapas, ganhosDaSafra),
       tables: [
         montarFunil(criados, etapas, deEntrada),
         montarPerdas(perdidos),

--- a/src/server/connectors/kommo.ts
+++ b/src/server/connectors/kommo.ts
@@ -44,6 +44,16 @@ interface LeadDoKommo {
     field_code?: string;
     values?: Array<{ value?: string | number | boolean }>;
   }> | null;
+  /**
+   * O motivo de perda nativo do Kommo, quando pedido com `with=loss_reason`.
+   *
+   * A documentação mostra ora um objeto, ora uma lista de um item — e as duas
+   * formas aparecem em contas reais. Aceitar as duas custa uma linha; supor a
+   * errada faz a tabela de perdas nascer vazia sem erro nenhum.
+   */
+  _embedded?: {
+    loss_reason?: { name?: string } | Array<{ name?: string }> | null;
+  } | null;
 }
 
 interface RespostaDeLeads {
@@ -131,6 +141,9 @@ async function buscarLeads(range: DateRange, campoDeData: "created_at" | "closed
   // vendas — `142` é etapa de ganho em **todo** funil, e um pipeline de
   // suporte com etapa de ganho entraria no faturamento sem ninguém notar.
   if (funil) url.searchParams.set("filter[pipeline_id]", funil);
+  // Sem `with`, o motivo de perda não vem — e a tabela de perdas nasce vazia
+  // sem nenhum sinal de que faltou pedir.
+  url.searchParams.set("with", "loss_reason");
   url.searchParams.set("limit", String(POR_PAGINA));
 
   const todos: LeadDoKommo[] = [];
@@ -329,6 +342,108 @@ function montarOrigens(criados: LeadDoKommo[], ganhos: LeadDoKommo[]): TableBloc
   };
 }
 
+/**
+ * Motivo da perda, venha ele de onde vier.
+ *
+ * O Kommo tem um motivo de perda nativo, mas nada obriga a clínica a usá-lo —
+ * aqui o time montou a lista como campo do próprio negócio, com as opções
+ * escritas por eles. As duas formas convivem numa mesma conta, e ler só uma
+ * delas produziria uma tabela vazia sem nenhum erro para investigar.
+ *
+ * O campo personalizado é procurado por conteúdo do nome, não por nome exato:
+ * "Motivo de perda", "Motivos da perda" e "MOTIVO DE PERDA" são a mesma coisa
+ * para quem preenche, e exigir a grafia certa quebraria no dia em que alguém
+ * renomeasse a etiqueta.
+ */
+function motivoDaPerda(lead: LeadDoKommo): string | null {
+  const nativo = lead._embedded?.loss_reason;
+  const primeiro = Array.isArray(nativo) ? nativo[0] : nativo;
+  const doKommo = primeiro?.name?.trim();
+  if (doKommo) return doKommo;
+
+  for (const item of lead.custom_fields_values ?? []) {
+    const nome = (item.field_name ?? "").toLowerCase();
+    const codigo = (item.field_code ?? "").toLowerCase();
+    const ehMotivo = codigo === "loss_reason" || (nome.includes("motivo") && nome.includes("perd"));
+    if (!ehMotivo) continue;
+
+    const valor = item.values?.[0]?.value;
+    if (valor === undefined || valor === null || valor === "") continue;
+    return String(valor).trim();
+  }
+
+  return null;
+}
+
+/**
+ * Perda que ainda pode virar venda.
+ *
+ * Decisão do comercial, não do código: preço, tempo e área de cobertura são as
+ * três que voltam — o orçamento muda, a agenda abre, a cobertura cresce. As
+ * demais ("preferiu concorrente", "não elegível", "não respondeu") entram para
+ * o arquivo.
+ *
+ * A classificação é por conteúdo do texto, e não por uma lista fechada de
+ * opções, porque a lista do Kommo é editada por quem opera o CRM. Opção nova
+ * cai em "arquivar" — o lado conservador: deixar de fora uma perda recuperável
+ * custa uma oportunidade, prometer recuperação de quem não volta custa a
+ * confiança na tela.
+ */
+const RECUPERAVEIS: Array<{ marca: RegExp }> = [
+  // "Preço fora do orçamento", "Achou caro sem ver valor"
+  { marca: /car[oa]|pre[çc]o|or[çc]amento/i },
+  // "Sem tempo no momento", "Vai pensar / precisa de tempo"
+  { marca: /tempo|pensar/i },
+  // "Fora da Área de Cobertura"
+  { marca: /[áa]rea|cobertura/i },
+];
+
+function ehRecuperavel(motivo: string): boolean {
+  return RECUPERAVEIS.some(({ marca }) => marca.test(motivo));
+}
+
+/**
+ * Por que os negócios se perderam — e quais dá para retomar.
+ *
+ * É a outra metade do funil. A tabela de etapas mostra onde as pessoas param;
+ * esta mostra por quê pararam, que é o que dá para agir em cima. A coluna de
+ * situação existe para separar a fila de retomada do arquivo morto sem
+ * depender de quem lê lembrar quais motivos voltam.
+ */
+function montarPerdas(perdidos: LeadDoKommo[]): TableBlock {
+  const porMotivo = new Map<string, { negocios: number; valor: number }>();
+
+  for (const lead of perdidos) {
+    const motivo = motivoDaPerda(lead) ?? "Sem motivo registrado";
+    const atual = porMotivo.get(motivo) ?? { negocios: 0, valor: 0 };
+    atual.negocios += 1;
+    atual.valor += lead.price ?? 0;
+    porMotivo.set(motivo, atual);
+  }
+
+  return {
+    title: "Motivos de perda",
+    description:
+      "Por que os negócios do período não fecharam. Preço, tempo e área de cobertura entram como recuperáveis — são as perdas que voltam quando o orçamento, a agenda ou a cobertura mudam.",
+    columns: [
+      { key: "motivo", label: "Motivo", align: "left" },
+      { key: "situacao", label: "Situação", align: "left" },
+      { key: "negocios", label: "Negócios", format: "integer", align: "right" },
+      { key: "valor", label: "Valor", format: "currency", align: "right" },
+    ],
+    rows: [...porMotivo.entries()]
+      .map(([motivo, dados]) => ({
+        motivo,
+        // Texto, e não cor: a situação precisa sobreviver a um print em preto
+        // e branco e a quem não distingue as duas cores.
+        situacao: ehRecuperavel(motivo) ? "Recuperável" : "Arquivar",
+        negocios: dados.negocios,
+        valor: Math.round(dados.valor * 100) / 100,
+      }))
+      .sort((a, b) => b.negocios - a.negocios || b.valor - a.valor),
+  };
+}
+
 export async function fetchVendasReport(range: DateRange): Promise<ChannelReport> {
   const forceMock = isForceMock();
 
@@ -361,6 +476,13 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
     const ganhos = fechados.filter((l) => l.status_id === GANHO);
     const receita = ganhos.reduce((acc, l) => acc + (l.price ?? 0), 0);
     const emAberto = criados.filter((l) => l.status_id !== GANHO && l.status_id !== PERDIDO);
+    // Perdas contam por fechamento, como as vendas: é a mesma pergunta com o
+    // sinal trocado — "o que se decidiu neste período".
+    const perdidos = fechados.filter((l) => l.status_id === PERDIDO);
+    const recuperaveis = perdidos.filter((l) => {
+      const motivo = motivoDaPerda(l);
+      return motivo !== null && ehRecuperavel(motivo);
+    });
     // Cortada entre os criados, não entre os fechados: é a fatia daquela safra
     // que já virou venda. Misturar "fechados no mês" com "criados no mês"
     // produziria uma taxa que pode passar de 100%.
@@ -417,6 +539,16 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
         ),
       );
     }
+    // Perda sem motivo é perda que não vira aprendizado: o negócio some do
+    // funil e ninguém sabe se dava para recuperar.
+    const semMotivo = perdidos.filter((l) => motivoDaPerda(l) === null).length;
+    if (semMotivo > 0) {
+      avisos.push(
+        avisoOperacao(
+          `${semMotivo} de ${perdidos.length} negócio(s) perdido(s) no período estão sem motivo registrado no Kommo. Sem o motivo não dá para separar a perda que volta da que fica arquivada.`,
+        ),
+      );
+    }
     if (semUtm && leads.length > 0) {
       avisos.push(
         avisoOperacao(
@@ -466,16 +598,29 @@ export async function fetchVendasReport(range: DateRange): Promise<ChannelReport
           // Sem fechamento no período não há ciclo. Comparar pintaria de verde
           // um "-100%" que significa "nada fechou".
           semComparacao: ciclos.length === 0,
-          hint: "Dias entre a criação do negócio e o fechamento, na média dos que fecharam.",
+          hint: "Dias entre a criação do negócio e a etapa de venda ganha, que é quando o pagamento entra. Média dos que fecharam no período.",
         },
         { key: "emAberto", label: "Em aberto", value: emAberto.length, format: "integer" },
+        {
+          key: "recuperaveis",
+          label: "Perdas recuperáveis",
+          value: recuperaveis.length,
+          format: "integer",
+          // Menos é melhor no total de perdas, mas não aqui: esta é a fatia
+          // das perdas que dá para retomar, e ela crescer não é piora.
+          hint: "Negócios perdidos por preço, tempo ou área de cobertura — os motivos que voltam quando o orçamento, a agenda ou a cobertura mudam. Estão detalhados na tabela de motivos.",
+        },
       ],
       series,
       seriesDefs: [
         { key: "receita", label: "Receita", format: "currency", slot: 5 },
         { key: "vendas", label: "Vendas", format: "integer", slot: 2 },
       ],
-      tables: [montarFunil(criados, etapas, deEntrada), montarOrigens(criados, ganhos)],
+      tables: [
+        montarFunil(criados, etapas, deEntrada),
+        montarPerdas(perdidos),
+        montarOrigens(criados, ganhos),
+      ],
       notices: avisos,
     };
   } catch (erro) {

--- a/tests/integration/kommo.test.ts
+++ b/tests/integration/kommo.test.ts
@@ -26,6 +26,8 @@ interface LeadFalso {
   created_at?: number;
   closed_at?: number;
   custom_fields_values?: Array<{ field_name?: string; values?: Array<{ value?: string }> }>;
+  /** O motivo de perda nativo do Kommo, como ele volta com `with=loss_reason`. */
+  _embedded?: { loss_reason?: { name?: string } | Array<{ name?: string }> };
 }
 
 /**
@@ -518,6 +520,129 @@ describe("vendas pelo Kommo", () => {
 
     const funil = report.tables.find((t) => t.title === "Negócios por etapa");
     expect(funil?.rows[0]?.etapa).toBe("Avaliação agendada");
+  });
+
+  it("agrupa as perdas por motivo e separa o que dá para retomar", async () => {
+    const perdido = (id: number, motivo: string, price: number): LeadFalso => ({
+      id,
+      price,
+      status_id: PERDIDO,
+      created_at: emSegundos("2026-02-02T10:00:00Z"),
+      closed_at: emSegundos("2026-02-10T10:00:00Z"),
+      _embedded: { loss_reason: { name: motivo } },
+    });
+
+    const { report } = await relatorio([
+      perdido(1, "Preço fora do orçamento", 1000),
+      perdido(2, "Preço fora do orçamento", 2000),
+      perdido(3, "Não respondeu após múltiplos contatos", 500),
+    ]);
+
+    const perdas = report.tables.find((t) => t.title === "Motivos de perda");
+
+    // Ordenado por volume: o motivo que mais derruba negócio abre a tabela.
+    expect(perdas?.rows).toEqual([
+      { motivo: "Preço fora do orçamento", situacao: "Recuperável", negocios: 2, valor: 3000 },
+      {
+        motivo: "Não respondeu após múltiplos contatos",
+        situacao: "Arquivar",
+        negocios: 1,
+        valor: 500,
+      },
+    ]);
+  });
+
+  it("reconhece as três perdas que o comercial considera recuperáveis", async () => {
+    const perdido = (id: number, motivo: string): LeadFalso => ({
+      id,
+      status_id: PERDIDO,
+      created_at: emSegundos("2026-02-02T10:00:00Z"),
+      closed_at: emSegundos("2026-02-10T10:00:00Z"),
+      _embedded: { loss_reason: { name: motivo } },
+    });
+
+    const { report } = await relatorio([
+      perdido(1, "Achou caro sem ver valor"),
+      perdido(2, "Sem tempo no momento"),
+      perdido(3, "Vai pensar / precisa de tempo"),
+      perdido(4, "Fora da Área de Cobertura"),
+      // Estas não voltam, e contá-las na fila de retomada faria o comercial
+      // gastar ligação com quem já decidiu.
+      perdido(5, "Preferiu concorrente ou outra solução"),
+      perdido(6, "Não elegível ao programa"),
+    ]);
+
+    expect(kpi(report, "recuperaveis")).toBe(4);
+  });
+
+  it("motivo novo, que ninguém classificou ainda, entra como arquivar", async () => {
+    const { report } = await relatorio([
+      {
+        id: 1,
+        status_id: PERDIDO,
+        created_at: emSegundos("2026-02-02T10:00:00Z"),
+        closed_at: emSegundos("2026-02-10T10:00:00Z"),
+        _embedded: { loss_reason: { name: "Mudou de cidade" } },
+      },
+    ]);
+
+    const perdas = report.tables.find((t) => t.title === "Motivos de perda");
+
+    // O lado conservador: prometer recuperação de quem não volta custa mais
+    // que deixar uma opção nova esperando classificação.
+    expect(perdas?.rows[0]?.situacao).toBe("Arquivar");
+    expect(kpi(report, "recuperaveis")).toBe(0);
+  });
+
+  it("lê o motivo também quando ele é campo do negócio, e não o nativo", async () => {
+    const { report } = await relatorio([
+      {
+        id: 1,
+        status_id: PERDIDO,
+        created_at: emSegundos("2026-02-02T10:00:00Z"),
+        closed_at: emSegundos("2026-02-10T10:00:00Z"),
+        // Grafia livre de propósito: quem opera o CRM renomeia a etiqueta, e
+        // exigir o nome exato faria a tabela esvaziar sem nenhum erro.
+        custom_fields_values: [
+          { field_name: "MOTIVO DA PERDA", values: [{ value: "Sem tempo no momento" }] },
+        ],
+      },
+    ]);
+
+    const perdas = report.tables.find((t) => t.title === "Motivos de perda");
+    expect(perdas?.rows[0]).toMatchObject({
+      motivo: "Sem tempo no momento",
+      situacao: "Recuperável",
+    });
+  });
+
+  it("perda sem motivo aparece na tabela e vira aviso", async () => {
+    const { report } = await relatorio([
+      {
+        id: 1,
+        status_id: PERDIDO,
+        created_at: emSegundos("2026-02-02T10:00:00Z"),
+        closed_at: emSegundos("2026-02-10T10:00:00Z"),
+      },
+    ]);
+
+    const perdas = report.tables.find((t) => t.title === "Motivos de perda");
+
+    // Perda sem motivo não vira aprendizado: o negócio some do funil e ninguém
+    // sabe se dava para recuperar. Some da tabela, some o problema.
+    expect(perdas?.rows[0]?.motivo).toBe("Sem motivo registrado");
+    expect(kpi(report, "recuperaveis")).toBe(0);
+    expect(report.notices.some((n) => /sem motivo registrado/i.test(n.text))).toBe(true);
+  });
+
+  it("pede o motivo de perda na consulta", async () => {
+    const { chamadas } = await relatorio([]);
+
+    const enderecos = chamadas.mock.calls.map(([entrada]) => String(entrada));
+
+    // Sem `with=loss_reason` o Kommo não devolve o motivo, e a tabela nasceria
+    // vazia sem nenhum sinal de que faltou pedir.
+    expect(enderecos.some((url) => url.includes("with=loss_reason"))).toBe(true);
   });
 
   it("sem credencial, cai em demonstração em vez de quebrar", async () => {

--- a/tests/integration/kommo.test.ts
+++ b/tests/integration/kommo.test.ts
@@ -645,6 +645,120 @@ describe("vendas pelo Kommo", () => {
     expect(enderecos.some((url) => url.includes("with=loss_reason"))).toBe(true);
   });
 
+  it("o funil da figura conta quem chegou, e não quem está parado", async () => {
+    const { report } = await relatorio(
+      [
+        // Parado na primeira etapa.
+        { id: 1, status_id: 20, created_at: emSegundos("2026-02-02T10:00:00Z") },
+        // Parado na terceira: já passou pelas duas anteriores.
+        { id: 2, status_id: 40, created_at: emSegundos("2026-02-03T10:00:00Z") },
+        // Ganho: passou por todas.
+        {
+          id: 3,
+          price: 900,
+          status_id: GANHO,
+          created_at: emSegundos("2026-02-04T10:00:00Z"),
+          closed_at: emSegundos("2026-02-06T10:00:00Z"),
+        },
+      ],
+      [
+        { id: 20, name: "Novo lead", sort: 10 },
+        { id: 30, name: "Qualificação", sort: 20 },
+        { id: 40, name: "Negociação", sort: 30 },
+      ],
+    );
+
+    // Ocupação diria 1 / 0 / 1: "ninguém em Qualificação", e a etapa do meio
+    // pareceria um gargalo que não existe — os dois de baixo passaram por lá.
+    expect(report.funnel?.stages.map((e) => [e.label, e.value])).toEqual([
+      ["Novo lead", 3],
+      ["Qualificação", 2],
+      ["Negociação", 2],
+      ["Venda ganha", 1],
+    ]);
+  });
+
+  it("o funil nunca alarga para baixo", async () => {
+    const { report } = await relatorio(
+      [
+        { id: 1, status_id: 20, created_at: emSegundos("2026-02-02T10:00:00Z") },
+        { id: 2, status_id: 30, created_at: emSegundos("2026-02-03T10:00:00Z") },
+        {
+          id: 3,
+          status_id: GANHO,
+          created_at: emSegundos("2026-02-04T10:00:00Z"),
+          closed_at: emSegundos("2026-02-05T10:00:00Z"),
+        },
+      ],
+      [
+        { id: 20, name: "Novo lead", sort: 10 },
+        { id: 30, name: "Qualificação", sort: 20 },
+      ],
+    );
+
+    const valores = report.funnel?.stages.map((e) => e.value) ?? [];
+
+    // Acumulado é monótono por definição. Uma etapa maior que a anterior seria
+    // erro de contagem — e desenharia uma figura que não é funil.
+    for (let i = 1; i < valores.length; i++) {
+      expect(valores[i]).toBeLessThanOrEqual(valores[i - 1]);
+    }
+  });
+
+  it("negócio perdido conta só na boca do funil, e a figura avisa", async () => {
+    const { report } = await relatorio(
+      [
+        { id: 1, status_id: 30, created_at: emSegundos("2026-02-02T10:00:00Z") },
+        {
+          id: 2,
+          status_id: PERDIDO,
+          created_at: emSegundos("2026-02-03T10:00:00Z"),
+          closed_at: emSegundos("2026-02-04T10:00:00Z"),
+        },
+      ],
+      [
+        { id: 20, name: "Novo lead", sort: 10 },
+        { id: 30, name: "Qualificação", sort: 20 },
+      ],
+    );
+
+    // O Kommo guarda só a etapa atual: um perdido em Qualificação não deixa
+    // rastro de onde estava. Creditá-lo à etapa seria inventar.
+    expect(report.funnel?.stages.map((e) => e.value)).toEqual([2, 1, 0]);
+    expect(report.funnel?.caveat).toMatch(/etapa atual/i);
+  });
+
+  it("a última faixa é o desfecho, e vem marcada como tal", async () => {
+    const { report } = await relatorio(
+      [
+        {
+          id: 1,
+          price: 500,
+          status_id: GANHO,
+          created_at: emSegundos("2026-02-02T10:00:00Z"),
+          closed_at: emSegundos("2026-02-04T10:00:00Z"),
+        },
+      ],
+      [{ id: 20, name: "Novo lead", sort: 10 }],
+    );
+
+    const ultima = report.funnel?.stages.at(-1);
+
+    // O ganho não é etapa de passagem: sai da rampa e ganha ícone e rótulo,
+    // porque cor trocada sozinha não diz que a categoria mudou.
+    expect(ultima).toMatchObject({ label: "Venda ganha", value: 1, outcome: "ganho", amount: 500 });
+  });
+
+  it("sem esqueleto de etapas não desenha funil nenhum", async () => {
+    const { report } = await relatorio([
+      { id: 1, status_id: 20, created_at: emSegundos("2026-02-02T10:00:00Z") },
+    ]);
+
+    // Sem a definição do funil no Kommo não há ordem — e funil fora de ordem
+    // não é funil. Melhor não desenhar do que desenhar errado.
+    expect(report.funnel).toBeUndefined();
+  });
+
   it("sem credencial, cai em demonstração em vez de quebrar", async () => {
     vi.stubEnv("KOMMO_ACCESS_TOKEN", "");
     vi.resetModules();

--- a/tests/unit/funnel-chart.test.tsx
+++ b/tests/unit/funnel-chart.test.tsx
@@ -47,8 +47,8 @@ describe("FunnelChart", () => {
   it("mostra a queda em relação à etapa anterior", () => {
     render(<FunnelChart block={BLOCO} />);
 
-    expect(screen.getByText("−50% da etapa anterior")).toBeInTheDocument();
-    expect(screen.getByText("−100% da etapa anterior")).toBeInTheDocument();
+    expect(screen.getByText("−50% da anterior")).toBeInTheDocument();
+    expect(screen.getByText("−100% da anterior")).toBeInTheDocument();
   });
 
   it("a porcentagem do topo sai em número inteiro", () => {

--- a/tests/unit/funnel-chart.test.tsx
+++ b/tests/unit/funnel-chart.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { FunnelChart } from "@/components/charts/funnel-chart";
+import type { FunnelBlock } from "@/lib/types";
+
+/**
+ * O funil desenhado.
+ *
+ * O que precisa ser travado aqui não é a aparência — é o que a forma promete:
+ * largura proporcional, etapa vazia ainda visível, e todo número também
+ * escrito em texto, porque uma figura sozinha não atende quem usa leitor de
+ * tela nem quem imprime a página.
+ */
+
+const BLOCO: FunnelBlock = {
+  title: "Do primeiro contato ao pagamento",
+  description: "Quantos chegaram a cada etapa.",
+  caveat: "Negócio perdido conta apenas na primeira etapa.",
+  stages: [
+    { label: "Novo lead", value: 100 },
+    { label: "Qualificação", value: 50 },
+    { label: "Negociação", value: 0 },
+    { label: "Venda ganha", value: 0, outcome: "ganho" },
+  ],
+};
+
+/** As quatro arestas de um `polygon(...)`, em ordem. */
+function arestas(estilo: string): number[] {
+  return [...estilo.matchAll(/([\d.]+)%\s+(?:0%|100%)/g)].map((m) => Number(m[1]));
+}
+
+describe("FunnelChart", () => {
+  it("cada número da figura também aparece escrito", () => {
+    render(<FunnelChart block={BLOCO} />);
+
+    // A figura é o atalho, não a fonte. Sem o texto ao lado, a tela não
+    // sobrevive a leitor de tela nem a uma impressão em preto e branco.
+    for (const etapa of BLOCO.stages) {
+      expect(screen.getByText(etapa.label)).toBeInTheDocument();
+    }
+    expect(screen.getByText("100")).toBeInTheDocument();
+    expect(screen.getByText("50")).toBeInTheDocument();
+    expect(screen.getAllByText("0")).toHaveLength(2);
+  });
+
+  it("mostra a queda em relação à etapa anterior", () => {
+    render(<FunnelChart block={BLOCO} />);
+
+    expect(screen.getByText("−50% da etapa anterior")).toBeInTheDocument();
+    expect(screen.getByText("−100% da etapa anterior")).toBeInTheDocument();
+  });
+
+  it("a porcentagem do topo sai em número inteiro", () => {
+    render(
+      <FunnelChart
+        block={{
+          title: "t",
+          stages: [
+            { label: "A", value: 358 },
+            { label: "B", value: 146 },
+          ],
+        }}
+      />,
+    );
+
+    // "40,78% do topo" ao lado de uma forma geométrica finge uma precisão que
+    // a figura não tem.
+    expect(screen.getByText("41% do topo")).toBeInTheDocument();
+    expect(screen.queryByText(/40,78/)).not.toBeInTheDocument();
+  });
+
+  it("etapa zerada continua visível em vez de sumir", () => {
+    const { container } = render(<FunnelChart block={BLOCO} />);
+
+    const formas = [...container.querySelectorAll<HTMLElement>("[style*='polygon']")];
+    const zerada = formas.at(-2);
+
+    // Largura zero levaria a linha inteira junto, e com ela o rótulo — quando
+    // "ninguém chega aqui" é justamente o que o funil precisa mostrar.
+    const pontos = arestas(zerada?.style.clipPath ?? "");
+    expect(pontos.length).toBe(4);
+    expect(pontos[1] - pontos[0]).toBeGreaterThan(0);
+  });
+
+  it("a largura acompanha o valor, e nunca alarga para baixo", () => {
+    const { container } = render(<FunnelChart block={BLOCO} />);
+
+    const formas = [...container.querySelectorAll<HTMLElement>("[style*='polygon']")];
+    // Cada faixa tem duas camadas com o mesmo recorte (a cor e o brilho).
+    const primeira = arestas(formas[0].style.clipPath);
+    const segunda = arestas(formas[2].style.clipPath);
+
+    const larguraDe = (p: number[]) => p[1] - p[0];
+
+    // Metade do valor, metade da largura: a codificação é linear.
+    expect(larguraDe(segunda)).toBeCloseTo(larguraDe(primeira) / 2, 1);
+    expect(larguraDe(segunda)).toBeLessThan(larguraDe(primeira));
+  });
+
+  it("diz o que a figura não consegue mostrar", () => {
+    render(<FunnelChart block={BLOCO} />);
+
+    expect(screen.getByText(/conta apenas na primeira etapa/i)).toBeInTheDocument();
+  });
+
+  it("sem etapas, não desenha nada", () => {
+    const { container } = render(<FunnelChart block={{ title: "t", stages: [] }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/tests/unit/funnel-chart.test.tsx
+++ b/tests/unit/funnel-chart.test.tsx
@@ -25,11 +25,17 @@ const BLOCO: FunnelBlock = {
   ],
 };
 
-/** A largura declarada de cada lâmina, em ordem, em pontos percentuais. */
+/** As quatro arestas de um `polygon(...)`, em ordem. */
+function arestas(estilo: string): number[] {
+  return [...estilo.matchAll(/([\d.]+)%\s+(?:0%|100%)/g)].map((m) => Number(m[1]));
+}
+
+/** A largura da aresta de cima de cada faixa, em ordem, em pontos percentuais. */
 function larguras(container: HTMLElement): number[] {
-  return [...container.querySelectorAll<HTMLElement>("[style*='width']")].map((el) =>
-    Number.parseFloat(el.style.width),
-  );
+  return [...container.querySelectorAll<HTMLElement>("[style*='polygon']")].map((el) => {
+    const [a, b] = arestas(el.style.clipPath);
+    return b - a;
+  });
 }
 
 describe("FunnelChart", () => {

--- a/tests/unit/funnel-chart.test.tsx
+++ b/tests/unit/funnel-chart.test.tsx
@@ -25,9 +25,11 @@ const BLOCO: FunnelBlock = {
   ],
 };
 
-/** As quatro arestas de um `polygon(...)`, em ordem. */
-function arestas(estilo: string): number[] {
-  return [...estilo.matchAll(/([\d.]+)%\s+(?:0%|100%)/g)].map((m) => Number(m[1]));
+/** A largura declarada de cada lâmina, em ordem, em pontos percentuais. */
+function larguras(container: HTMLElement): number[] {
+  return [...container.querySelectorAll<HTMLElement>("[style*='width']")].map((el) =>
+    Number.parseFloat(el.style.width),
+  );
 }
 
 describe("FunnelChart", () => {
@@ -73,29 +75,21 @@ describe("FunnelChart", () => {
   it("etapa zerada continua visível em vez de sumir", () => {
     const { container } = render(<FunnelChart block={BLOCO} />);
 
-    const formas = [...container.querySelectorAll<HTMLElement>("[style*='polygon']")];
-    const zerada = formas.at(-2);
+    const zerada = larguras(container).at(-1);
 
-    // Largura zero levaria a linha inteira junto, e com ela o rótulo — quando
+    // Largura zero levaria a lâmina inteira junto, e com ela o rótulo — quando
     // "ninguém chega aqui" é justamente o que o funil precisa mostrar.
-    const pontos = arestas(zerada?.style.clipPath ?? "");
-    expect(pontos.length).toBe(4);
-    expect(pontos[1] - pontos[0]).toBeGreaterThan(0);
+    expect(zerada).toBeGreaterThan(0);
   });
 
   it("a largura acompanha o valor, e nunca alarga para baixo", () => {
     const { container } = render(<FunnelChart block={BLOCO} />);
 
-    const formas = [...container.querySelectorAll<HTMLElement>("[style*='polygon']")];
-    // Cada faixa tem duas camadas com o mesmo recorte (a cor e o brilho).
-    const primeira = arestas(formas[0].style.clipPath);
-    const segunda = arestas(formas[2].style.clipPath);
-
-    const larguraDe = (p: number[]) => p[1] - p[0];
+    const [primeira, segunda] = larguras(container);
 
     // Metade do valor, metade da largura: a codificação é linear.
-    expect(larguraDe(segunda)).toBeCloseTo(larguraDe(primeira) / 2, 1);
-    expect(larguraDe(segunda)).toBeLessThan(larguraDe(primeira));
+    expect(segunda).toBeCloseTo(primeira / 2, 1);
+    expect(segunda).toBeLessThan(primeira);
   });
 
   it("diz o que a figura não consegue mostrar", () => {


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — nasce da definição do processo comercial fechada com a
gerência: funil de três etapas (Novo lead → Qualificação → Negociação), ganho
quando o pagamento entra, e **motivo de perda como campo do negócio** em vez de
uma etapa por tipo de perda. Abro a Issue de Nova função referenciando este PR.

## 1. Motivos de perda

O comercial decidiu não criar etapa para cada tipo de perda. A leitura que
interessa é uma só: **desta perda dá para voltar, desta não.** Preço, tempo e
área de cobertura voltam — o orçamento muda, a agenda abre, a cobertura cresce.
"Preferiu concorrente", "não elegível", "não respondeu" ficam no arquivo.

- Tabela nova, ordenada por volume, com a situação escrita **em texto** — não em
  cor, que não sobrevive a um print em preto e branco nem a quem não distingue
  as duas.
- Indicador **"Perdas recuperáveis"**: a fila de retomada do mês. Sem comparação
  com o período anterior, de propósito — esse número não tem lado bom. Subir
  pode ser "perdemos mais" ou "perdemos mais gente que volta".
- O motivo é lido do **campo nativo do Kommo e também de campo criado à mão**,
  porque as duas formas convivem numa conta e ler só uma produziria tabela
  vazia sem nenhum erro para investigar. O campo à mão é procurado por conteúdo
  do nome: quem opera o CRM renomeia etiqueta, e exigir grafia exata quebraria
  em silêncio.
- **Motivo que ninguém classificou ainda entra como "arquivar"** — prometer
  recuperação de quem já decidiu custa mais que deixar uma opção nova esperando.
- Perda sem motivo preenchido aparece na tabela e vira aviso.

## 2. O funil em figura

A tabela de etapas conta **ocupação** — quantos estão parados em cada etapa
agora. Desenhar aquilo como funil seria errado: um negócio em Negociação já
passou por Qualificação, e a etapa do meio apareceria como um gargalo que não
existe.

A figura conta outra coisa: **quantos chegaram a cada etapa.** A largura de cada
aresta é a contagem daquela etapa, e a inclinação entre duas arestas é a perda
entre elas. Onde a forma aperta é onde o processo trava.

### O desenho

Um cone contínuo no **slab escuro da marca** — o mesmo da navegação e da tela de
entrada —, com caixa de rótulo de um lado, caixa de números do outro e fio
ligando as duas à faixa. Passou por três formatos até chegar aqui; os dois
descartados (lâminas empilhadas e pílulas soltas) estão no histórico do branch.

Decisões que valem comentário, todas verificáveis nos testes:

- **Largura é a única codificação de grandeza.** A cor só ordena, num hue só.
- **A rampa não varia por tema.** O funil mora sempre no slab escuro, e
  superfície fixa é o que permite validar a rampa uma vez em vez de manter duas.
  Sobre `#2f2535` quem tem mais volume precisa de mais luz, então a ordem vai do
  passo mais claro para o mais fechado.
- **A boca ocupa 82% da coluna, não a coluna inteira.** Aberta demais, a
  primeira etapa vira prancha e as seguintes viram blocos — some a silhueta, que
  é a única razão de existir um desenho aqui em vez de só a tabela.
- **Boca e bica arredondadas.** Recorte poligonal não aceita raio, e quina viva
  no meio de uma interface arredondada em todo o resto lê como peça de outro
  projeto. As pontas ganham uma tampa própria: retângulo de raio total na mesma
  largura da aresta, encaixado sem costura. O degradê é horizontal justamente
  para não deixar emenda entre tampa e corpo.
- **Na última faixa o estreitamento é desenho, não dado.** Ali não há próxima
  etapa para medir; sem isso a peça terminaria num tarugo cortado reto.
- **O ganho sai da rampa** e vem com troféu e rótulo: não é etapa de passagem, e
  cor trocada sozinha não avisa que a categoria mudou.
- **Sem tooltip, de propósito.** Etapa, contagem, porcentagem e queda estão todas
  escritas ao lado da forma — um tooltip repetiria o visível e esconderia o dado
  de quem navega por teclado. No telefone a figura some e sobra o texto, que já
  é o funil.
- **Etapa zerada mantém um traço visível** em vez de desaparecer: "ninguém chega
  aqui" é exatamente o que o funil precisa mostrar.
- Porcentagem em número inteiro: "−59,22%" ao lado de uma forma geométrica finge
  uma precisão que a figura não tem.

### A limitação, dita na própria tela

**Negócio perdido conta apenas na boca do funil.** O Kommo guarda só a etapa
atual, e a etapa atual de um perdido é "perdido" — quem morreu em Negociação não
deixa rastro de onde estava. Creditá-lo à última etapa conhecida inventaria um
número; contá-lo só na entrada subestima o meio do funil, e é o erro que dá para
admitir em voz alta. A ressalva vai impressa embaixo da figura.

## Como foi validado

- [x] `npm run verify` — **258 testes** (12 novos), lint, tipos e contrato de arquitetura
- [x] `npm run test:e2e` — 46/46
- [x] `npm run build` limpo
- [x] Renderizado e conferido a olho nos **dois temas**, em 1280px e no recorte móvel

Testes novos cobrem: agrupamento e classificação dos motivos; as três perdas
recuperáveis reconhecidas e as demais não; motivo desconhecido caindo em
"arquivar"; motivo vindo de campo personalizado com grafia livre; perda sem
motivo virando aviso; `with=loss_reason` presente na consulta; o funil contando
chegada e não ocupação; monotonia (o funil nunca alarga para baixo); perdido só
na boca; o desfecho marcado como tal; ausência de esqueleto não desenhando
figura nenhuma; e, no componente, largura linear, etapa zerada visível,
porcentagem inteira e todo número também em texto.

## Riscos e limitações

**A classificação de recuperável é por palavra no texto do motivo**, não por uma
lista fechada de ids — a lista do Kommo é editada por quem opera o CRM. Opção
nova cai em "arquivar" até alguém revisar. É o lado conservador, mas é uma regra
que mora no código e não no CRM: se o comercial mudar o critério, muda aqui.

**O funil só existe quando o Kommo devolve a definição das etapas.** Sem o
esqueleto não há ordem, e funil fora de ordem não é funil — melhor não desenhar.

**Com poucas etapas e queda forte, a silhueta fica desigual.** É o dado: de 358
para 146 são 59% a menos, e suavizar isso para o desenho ficar simétrico tiraria
justamente o que o funil serve para mostrar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_