### PR TITLE
feat: o diagnóstico responde em uma linha se o token do Google Ads já liberou

### DIFF
--- a/src/app/api/diagnostico/google/route.ts
+++ b/src/app/api/diagnostico/google/route.ts
@@ -282,12 +282,26 @@ export async function GET(request: Request) {
             const contas = (dados.resourceNames ?? []).map((r) => r.replace("customers/", ""));
             const alvo = env.GOOGLE_ADS_CUSTOMER_ID?.replace(/-/g, "");
             const encontrada = alvo ? contas.includes(alvo) : false;
-            return `${contas.length} conta(s) acessível(is).${
+
+            // Esta chamada ignora `login-customer-id`: ela lista o que o
+            // usuário do OAuth alcança **direto**. Por isso a ausência da conta
+            // gerente aqui é informação, e não detalhe — é a explicação do 403
+            // que aparece na consulta seguinte.
+            const gerente = env.GOOGLE_ADS_LOGIN_CUSTOMER_ID?.replace(/-/g, "");
+            const gerenteAlcancavel = gerente ? contas.includes(gerente) : null;
+
+            return `${contas.length} conta(s) acessível(is): ${contas.map(mascarar).join(", ")}.${
               alvo
                 ? encontrada
                   ? " A conta configurada está entre elas."
-                  : ` A conta configurada (${mascarar(alvo)}) NÃO está entre elas — verifique GOOGLE_ADS_LOGIN_CUSTOMER_ID.`
+                  : ` A conta configurada (${mascarar(alvo)}) NÃO está entre elas.`
                 : " GOOGLE_ADS_CUSTOMER_ID não configurado."
+            }${
+              gerenteAlcancavel === false
+                ? ` A conta gerente configurada (${mascarar(gerente as string)}) NÃO está entre elas — este login não a alcança, e entrar por ela é o que devolve 403 na consulta.`
+                : gerenteAlcancavel === true
+                  ? " A conta gerente configurada também está entre elas."
+                  : ""
             }`;
           },
         ),
@@ -296,6 +310,17 @@ export async function GET(request: Request) {
       // 4. Google Ads — a consulta real funciona?
       if (env.GOOGLE_ADS_CUSTOMER_ID) {
         const range = rangeFromPreset("7d");
+        const consulta = `SELECT segments.date, metrics.cost_micros FROM customer WHERE segments.date BETWEEN '${range.from}' AND '${range.to}'`;
+        const enderecoDaConsulta = `https://googleads.googleapis.com/${versaoAds}/customers/${env.GOOGLE_ADS_CUSTOMER_ID.replace(/-/g, "")}/googleAds:searchStream`;
+
+        const resumirConsulta = (d: unknown) => {
+          const blocos = d as Array<{ results?: unknown[] }>;
+          const linhas = blocos.flatMap((b) => b.results ?? []);
+          return linhas.length === 0
+            ? "Consulta aceita, mas sem linhas — nenhuma entrega no período."
+            : `${linhas.length} dia(s) com dado.`;
+        };
+
         etapas.push(
           await requisitar(
             "ads-consulta",
@@ -305,20 +330,45 @@ export async function GET(request: Request) {
               init: {
                 method: "POST",
                 headers: { ...cabecalhos, "content-type": "application/json" },
-                body: JSON.stringify({
-                  query: `SELECT segments.date, metrics.cost_micros FROM customer WHERE segments.date BETWEEN '${range.from}' AND '${range.to}'`,
-                }),
+                body: JSON.stringify({ query: consulta }),
               },
             },
-            (d) => {
-              const blocos = d as Array<{ results?: unknown[] }>;
-              const linhas = blocos.flatMap((b) => b.results ?? []);
-              return linhas.length === 0
-                ? "Consulta aceita, mas sem linhas — nenhuma entrega no período."
-                : `${linhas.length} dia(s) com dado.`;
-            },
+            resumirConsulta,
           ),
         );
+
+        // 4b. A mesma consulta, sem entrar pela conta gerente.
+        //
+        // Só roda quando a de cima falhou e existe gerente configurado, e é o
+        // que transforma um palpite em resposta: se esta passa, o problema é o
+        // cabeçalho `login-customer-id`, não a credencial nem a conta. Sem
+        // isso, descobrir a causa exige apagar uma variável em produção e
+        // torcer — que é exatamente o que ninguém deveria precisar fazer para
+        // ler um diagnóstico.
+        const consultaFalhou = etapas.at(-1)?.ok === false;
+        if (consultaFalhou && env.GOOGLE_ADS_LOGIN_CUSTOMER_ID) {
+          const semGerente: Record<string, string> = {
+            ...cabecalhos,
+            "content-type": "application/json",
+          };
+          delete semGerente["login-customer-id"];
+
+          etapas.push(
+            await requisitar(
+              "ads-consulta-sem-gerente",
+              "E sem entrar pela conta gerente, a mesma consulta responde?",
+              {
+                url: enderecoDaConsulta,
+                init: {
+                  method: "POST",
+                  headers: semGerente,
+                  body: JSON.stringify({ query: consulta }),
+                },
+              },
+              resumirConsulta,
+            ),
+          );
+        }
       }
     } else {
       etapas.push({

--- a/src/app/api/diagnostico/google/route.ts
+++ b/src/app/api/diagnostico/google/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { rangeFromPreset } from "@/lib/date-range";
 import { VERSOES_CANDIDATAS } from "@/server/connectors/google-ads";
+import { type Etapa, veredictoDoToken } from "@/server/diagnostico/veredicto-ads";
 import { getCredentials, getEnv } from "@/server/env";
 import { guard } from "@/server/lib/api";
 import { redactSecrets } from "@/server/lib/http";
@@ -18,14 +19,6 @@ export const maxDuration = 30;
  * (OAuth + developer token + conta gerente + propriedade), e cada elo falha
  * com uma mensagem diferente.
  */
-
-interface Etapa {
-  etapa: string;
-  descricao: string;
-  status: number | null;
-  ok: boolean;
-  resultado: string;
-}
 
 function mascarar(valor: string): string {
   if (valor.length <= 10) return valor;
@@ -346,6 +339,11 @@ export async function GET(request: Request) {
       conclusao: primeiraFalha
         ? `Quebra na etapa "${primeiraFalha.etapa}": ${primeiraFalha.descricao}`
         : "Cadeia completa funcionando para os canais configurados.",
+      // A pergunta que mais se faz nesta página, respondida em uma linha em vez
+      // de escondida dentro do texto cru de uma etapa. Enquanto o Google não
+      // aprova o acesso básico, o Google Ads fica no snapshot exportado — e é
+      // esta a única coisa que decide se a tela vira tempo real.
+      tokenDeDesenvolvedor: veredictoDoToken(etapas),
       escopos: {
         concedidos: escopos || null,
         // Escopo ausente é a causa mais comum de 403 que parece problema de conta.

--- a/src/server/diagnostico/veredicto-ads.ts
+++ b/src/server/diagnostico/veredicto-ads.ts
@@ -1,0 +1,67 @@
+import "server-only";
+
+/**
+ * Leitura do diagnóstico do Google, separada da rota.
+ *
+ * Um Route Handler do Next só pode exportar os verbos HTTP e a configuração da
+ * rota — qualquer outro `export` reprova na checagem de tipos do build. A regra
+ * é chata, mas puxa a lógica para onde ela é testável sem subir um servidor, que
+ * é onde ela deveria estar de qualquer jeito.
+ */
+
+/** Um degrau da cadeia de credenciais, como a rota o registra. */
+export interface Etapa {
+  etapa: string;
+  descricao: string;
+  status: number | null;
+  ok: boolean;
+  resultado: string;
+}
+
+/**
+ * O token de desenvolvedor já saiu do acesso de teste?
+ *
+ * Um token recém-criado lê apenas contas de teste: qualquer consulta à conta
+ * real volta com `DEVELOPER_TOKEN_NOT_APPROVED`. É um estado esperado, não um
+ * erro de configuração — e é o único degrau entre o Google Ads em snapshot e o
+ * Google Ads em tempo real. Quem espera a aprovação abre esta página várias
+ * vezes por dia; a resposta merece uma linha própria.
+ */
+export function veredictoDoToken(etapas: Etapa[]): {
+  situacao: "aprovado" | "acesso de teste" | "não configurado" | "indeterminado";
+  explicacao: string;
+} {
+  const doAds = etapas.filter((e) => e.etapa.startsWith("ads"));
+  if (doAds.length === 0) {
+    return {
+      situacao: "não configurado",
+      explicacao:
+        "Nenhuma consulta ao Google Ads foi tentada — falta credencial antes deste degrau.",
+    };
+  }
+
+  if (
+    doAds.some((e) => /DEVELOPER_TOKEN_NOT_APPROVED|DEVELOPER_TOKEN_PROHIBITED/i.test(e.resultado))
+  ) {
+    return {
+      situacao: "acesso de teste",
+      explicacao:
+        "O Google ainda não liberou o acesso básico. Enquanto isso o painel mostra o snapshot exportado da plataforma. O token não muda quando for aprovado — só o nível de acesso, e a tela vira tempo real sozinha no próximo carregamento.",
+    };
+  }
+
+  // Consulta aceita é a única prova de aprovação. Um período sem entrega
+  // devolve zero linhas, e zero linhas continua sendo consulta aceita.
+  if (doAds.some((e) => e.etapa === "ads-consulta" && e.ok)) {
+    return {
+      situacao: "aprovado",
+      explicacao: "A conta real respondeu. O Google Ads está lendo em tempo real.",
+    };
+  }
+
+  return {
+    situacao: "indeterminado",
+    explicacao:
+      "A consulta ao Google Ads falhou por outro motivo — veja a etapa que quebrou. Não é o nível de acesso do token.",
+  };
+}

--- a/tests/unit/veredicto-token-ads.test.ts
+++ b/tests/unit/veredicto-token-ads.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { veredictoDoToken } from "@/server/diagnostico/veredicto-ads";
+
+/**
+ * O veredicto do token de desenvolvedor.
+ *
+ * É a linha que decide se o Google Ads está em tempo real ou preso no snapshot
+ * exportado, e quem espera a aprovação do Google recarrega essa página várias
+ * vezes por dia. Errar aqui manda alguém abrir chamado com o suporte do Google
+ * por um problema que é outro — ou pior, faz parar de olhar quando já liberou.
+ */
+
+const etapa = (parcial: Partial<{ etapa: string; ok: boolean; resultado: string }>) => ({
+  etapa: "ads-consulta",
+  descricao: "",
+  status: 200,
+  ok: true,
+  resultado: "",
+  ...parcial,
+});
+
+describe("veredictoDoToken", () => {
+  it("reconhece o token ainda em acesso de teste", () => {
+    const veredicto = veredictoDoToken([
+      etapa({
+        etapa: "ads-acesso",
+        ok: false,
+        resultado:
+          '{"error":{"details":[{"errors":[{"errorCode":{"authorizationError":"DEVELOPER_TOKEN_NOT_APPROVED"}}]}]}}',
+      }),
+    ]);
+
+    expect(veredicto.situacao).toBe("acesso de teste");
+    // Quem lê precisa saber que não há nada a fazer no painel — e que a tela
+    // vira sozinha quando o Google liberar.
+    expect(veredicto.explicacao).toMatch(/snapshot/i);
+  });
+
+  it("trata token proibido como o mesmo estado de espera", () => {
+    const veredicto = veredictoDoToken([
+      etapa({ etapa: "ads-versao", ok: false, resultado: "DEVELOPER_TOKEN_PROHIBITED" }),
+    ]);
+
+    expect(veredicto.situacao).toBe("acesso de teste");
+  });
+
+  it("consulta aceita é a prova de que foi aprovado", () => {
+    const veredicto = veredictoDoToken([
+      etapa({ etapa: "ads-acesso", resultado: "2 conta(s)." }),
+      etapa({ etapa: "ads-consulta", resultado: "7 dia(s) com dado." }),
+    ]);
+
+    expect(veredicto.situacao).toBe("aprovado");
+  });
+
+  it("período sem entrega continua sendo aprovação", () => {
+    const veredicto = veredictoDoToken([
+      etapa({ etapa: "ads-consulta", resultado: "Consulta aceita, mas sem linhas." }),
+    ]);
+
+    // Zero linhas é resposta da conta real. Ler isso como "não aprovado" faria
+    // alguém abrir chamado por causa de uma semana sem investimento.
+    expect(veredicto.situacao).toBe("aprovado");
+  });
+
+  it("outra falha não vira problema de token", () => {
+    const veredicto = veredictoDoToken([
+      etapa({ etapa: "ads-consulta", ok: false, resultado: "USER_PERMISSION_DENIED" }),
+    ]);
+
+    expect(veredicto.situacao).toBe("indeterminado");
+    expect(veredicto.explicacao).toMatch(/não é o nível de acesso/i);
+  });
+
+  it("sem nenhuma tentativa ao Ads, diz que falta configuração", () => {
+    const veredicto = veredictoDoToken([etapa({ etapa: "oauth" }), etapa({ etapa: "ga4" })]);
+
+    expect(veredicto.situacao).toBe("não configurado");
+  });
+});


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — nasce de uma pergunta que se repete: "o token do Google Ads
já liberou?". Abro a Issue de Melhoria referenciando este PR.

## Contexto

O token de desenvolvedor nasce com **acesso de teste** e só lê contas de teste.
Enquanto o Google não aprova o acesso básico, o Google Ads fica no snapshot
exportado da plataforma — e esse é o **único degrau** entre a tela e o tempo
real.

A resposta já estava em `/api/diagnostico/google`, mas escondida dentro do texto
cru de uma etapa, entre JSON de erro. Quem espera a aprovação abre essa página
várias vezes por dia; a pergunta merece uma linha própria.

## O que mudou

A resposta ganha `tokenDeDesenvolvedor`, com situação e explicação:

| Situação | Quando |
|---|---|
| `aprovado` | A consulta à conta real foi aceita |
| `acesso de teste` | Voltou `DEVELOPER_TOKEN_NOT_APPROVED` ou `_PROHIBITED` |
| `não configurado` | Nenhuma consulta ao Ads chegou a ser tentada |
| `indeterminado` | Falhou por outro motivo — e a explicação diz que **não** é o nível de acesso |

Duas decisões que valem comentário:

**Período sem entrega continua sendo aprovação.** Uma consulta aceita devolve
zero linhas quando não houve investimento. Ler zero linhas como "não aprovado"
faria alguém abrir chamado com o Google por causa de uma semana parada.

**Falha por outro motivo não vira problema de token.** `USER_PERMISSION_DENIED`
é permissão de usuário, não nível de acesso — e mandar cobrar do Google o que
se resolve na conta gerente custa dias.

A função saiu da rota para `src/server/diagnostico/veredicto-ads.ts`. Route
Handler do Next só pode exportar os verbos HTTP e a configuração da rota;
qualquer outro `export` reprova na checagem de tipos do build. Regra chata que,
neste caso, puxa a lógica para onde ela é testável sem subir servidor.

## Como foi validado

- [x] `npm run verify` — **246 testes** (6 novos), lint, tipos e contrato de arquitetura
- [x] `npm run build` limpo

Testes novos cobrem os quatro veredictos, incluindo os dois casos que enganam:
zero linhas lido como aprovação, e falha alheia não virando problema de token.

Não deu para exercitar contra a API real: o ambiente onde isto foi escrito não
tem as credenciais, e elas não devem sair da Vercel. O teste cobre a leitura das
respostas, não a chamada.

## Riscos e limitações

**O veredicto lê o texto do erro.** Se o Google mudar o código de erro, a
situação vira `indeterminado` em vez de `acesso de teste` — falha para o lado
menos ruim: pede para olhar a etapa que quebrou em vez de afirmar algo errado.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_