### PR TITLE
fix: o diagnóstico do Google para de sugerir aprovação que não prova

### DIFF
--- a/src/app/api/diagnostico/google/route.ts
+++ b/src/app/api/diagnostico/google/route.ts
@@ -411,6 +411,17 @@ export async function GET(request: Request) {
         propriedadeGa4: env.GA4_PROPERTY_ID ? mascarar(env.GA4_PROPERTY_ID) : null,
         contaAds: env.GOOGLE_ADS_CUSTOMER_ID ? mascarar(env.GOOGLE_ADS_CUSTOMER_ID) : null,
         usaContaGerente: Boolean(env.GOOGLE_ADS_LOGIN_CUSTOMER_ID),
+        // Pontas do token de desenvolvedor, para conferir contra a Central de
+        // API sem o valor sair daqui.
+        //
+        // Existe porque há um caso que nenhuma outra linha desta resposta
+        // distingue: o acesso básico aprovado num token e o painel usando
+        // outro — gerado noutra conta gerente, ou regerado depois. Os dois
+        // cenários produzem exatamente o mesmo `DEVELOPER_TOKEN_NOT_APPROVED`,
+        // e sem comparar as pontas a investigação anda em círculo.
+        tokenDesenvolvedor: env.GOOGLE_ADS_DEVELOPER_TOKEN
+          ? mascarar(env.GOOGLE_ADS_DEVELOPER_TOKEN)
+          : null,
         credenciais: getCredentials(),
       },
       etapas,

--- a/src/app/api/diagnostico/google/route.ts
+++ b/src/app/api/diagnostico/google/route.ts
@@ -272,7 +272,7 @@ export async function GET(request: Request) {
       etapas.push(
         await requisitar(
           "ads-acesso",
-          "O developer token é aceito e quais contas ele alcança?",
+          "Quais contas este login alcança? (não prova aprovação do token)",
           {
             url: `https://googleads.googleapis.com/${versaoAds}/customers:listAccessibleCustomers`,
             init: { headers: cabecalhos },
@@ -283,14 +283,20 @@ export async function GET(request: Request) {
             const alvo = env.GOOGLE_ADS_CUSTOMER_ID?.replace(/-/g, "");
             const encontrada = alvo ? contas.includes(alvo) : false;
 
-            // Esta chamada ignora `login-customer-id`: ela lista o que o
-            // usuário do OAuth alcança **direto**. Por isso a ausência da conta
-            // gerente aqui é informação, e não detalhe — é a explicação do 403
-            // que aparece na consulta seguinte.
+            // Duas armadilhas nesta chamada, e as duas já custaram uma
+            // conclusão errada.
+            //
+            // Ela **responde 200 com token de acesso de teste**. Passar aqui não
+            // diz nada sobre aprovação — quem prova isso é a consulta a uma
+            // conta de produção, na etapa seguinte.
+            //
+            // E ela **ignora `login-customer-id`**: lista o que o usuário do
+            // OAuth alcança direto. Por isso a ausência da conta gerente aqui é
+            // informação, e não detalhe.
             const gerente = env.GOOGLE_ADS_LOGIN_CUSTOMER_ID?.replace(/-/g, "");
             const gerenteAlcancavel = gerente ? contas.includes(gerente) : null;
 
-            return `${contas.length} conta(s) acessível(is): ${contas.map(mascarar).join(", ")}.${
+            return `${contas.length} conta(s) acessível(is): ${contas.map(mascarar).join(", ")}. Esta chamada responde mesmo com token de acesso de teste, então passar aqui não prova aprovação.${
               alvo
                 ? encontrada
                   ? " A conta configurada está entre elas."

--- a/tests/unit/veredicto-token-ads.test.ts
+++ b/tests/unit/veredicto-token-ads.test.ts
@@ -73,6 +73,23 @@ describe("veredictoDoToken", () => {
     expect(veredicto.explicacao).toMatch(/não é o nível de acesso/i);
   });
 
+  it("consulta aceita numa etapa não apaga o acesso de teste declarado em outra", () => {
+    const veredicto = veredictoDoToken([
+      // `listAccessibleCustomers` responde 200 com token de teste. Foi
+      // exatamente essa etapa que, lida sozinha, fez concluir que o token
+      // estava aprovado quando não estava.
+      etapa({ etapa: "ads-acesso", resultado: "1 conta(s) acessível(is): 7062904143." }),
+      etapa({ etapa: "ads-consulta", ok: false, resultado: "USER_PERMISSION_DENIED" }),
+      etapa({
+        etapa: "ads-consulta-sem-gerente",
+        ok: false,
+        resultado: "DEVELOPER_TOKEN_NOT_APPROVED",
+      }),
+    ]);
+
+    expect(veredicto.situacao).toBe("acesso de teste");
+  });
+
   it("sem nenhuma tentativa ao Ads, diz que falta configuração", () => {
     const veredicto = veredictoDoToken([etapa({ etapa: "oauth" }), etapa({ etapa: "ga4" })]);
 


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — nasce de um diagnóstico errado que este próprio endpoint
induziu. Abro a Issue de Correção referenciando este PR.

## O que aconteceu

Investigando por que o Google Ads seguia no snapshot, li a etapa `ads-acesso`
passando com `200` e concluí que o token de desenvolvedor estava aprovado. Não
estava: a consulta a uma conta de produção voltava
`DEVELOPER_TOKEN_NOT_APPROVED`.

`customers:listAccessibleCustomers` **responde 200 mesmo com token de acesso de
teste**. A etapa se chamava *"O developer token é aceito e quais contas ele
alcança?"* — e, ao passar, lia como aprovação. A conclusão errada custou uma
variável apagada em produção atrás de um problema que era outro.

## O que mudou

**A etapa deixa de prometer o que não verifica.** A pergunta passa a ser só
sobre alcance, e o resultado avisa que passar ali não prova nada sobre nível de
acesso — quem prova é a consulta a uma conta real, na etapa seguinte.

**O token de desenvolvedor aparece mascarado** em `configuracao`, com o mesmo
tratamento já usado para as contas: primeiros seis e últimos quatro caracteres.
Existe para um caso que nenhuma outra linha da resposta distingue — o acesso
básico aprovado num token e o painel usando outro, gerado noutra conta gerente
ou regerado depois. Os dois cenários produzem exatamente o mesmo
`DEVELOPER_TOKEN_NOT_APPROVED`, e sem comparar as pontas a investigação anda em
círculo.

## Como foi validado

- [x] `npm run verify` — **265 testes** (1 novo), lint, tipos e contrato de arquitetura
- [x] `npm run build` limpo

O teste novo trava exatamente o caso que enganou: etapa de acesso passando,
consulta com gerente devolvendo `USER_PERMISSION_DENIED` e consulta sem gerente
devolvendo `DEVELOPER_TOKEN_NOT_APPROVED` — o veredicto tem que ser
`acesso de teste`.

## Riscos e limitações

**O mascaramento mostra dez caracteres do token.** É o mesmo critério já
aplicado aos identificadores de conta, e a rota inteira está atrás da senha do
painel. Ainda assim é mais superfície do que antes, e existe por uma razão
concreta: sem isso não há como distinguir "token não aprovado" de "token
errado".

**A rota continua sem prova de aprovação própria.** Ela infere do texto do erro
da consulta real, que é o único sinal que a API dá. Se o Google mudar o código
de erro, o veredicto cai em `indeterminado` — o lado seguro.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_