### PR TITLE
feat: auditoria de UTM dos anúncios da Meta

### DIFF
--- a/src/app/api/diagnostico/utm/route.ts
+++ b/src/app/api/diagnostico/utm/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+
+import { type AnuncioDaMeta, auditarUtms } from "@/server/diagnostico/utm-meta";
+import { getEnv } from "@/server/env";
+import { guard } from "@/server/lib/api";
+import { descreverFalha, httpJson, metaAuthHeaders } from "@/server/lib/http";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+/**
+ * Auditoria de UTM dos anúncios da Meta.
+ *
+ * Responde a uma pergunta que só se responde anúncio por anúncio: quais peças
+ * mandam origem junto com o clique e quais não mandam. Sem isso o negócio chega
+ * ao Kommo sem procedência, e a tabela "Vendas por origem" acumula tudo em
+ * "Sem UTM" — o painel sabe quanto se investiu e quanto se vendeu, mas não liga
+ * as duas pontas.
+ *
+ * Só leitura. Corrigir a URL de um anúncio no ar é mudança na conta do cliente,
+ * e o painel não tem — nem deve ter — permissão de escrita para isso.
+ */
+
+/**
+ * Anúncios pausados entram na conta.
+ *
+ * Peça pausada volta a rodar, e volta com a configuração que tinha. Auditar só
+ * as ativas deixa a dívida escondida até o dia em que alguém reativa a campanha
+ * antiga e o rastreamento some sem ninguém entender por quê.
+ */
+const STATUS = ["ACTIVE", "PAUSED"];
+
+interface RespostaDeAnuncios {
+  data?: AnuncioDaMeta[];
+  paging?: { next?: string };
+}
+
+const CAMPOS = [
+  "id",
+  "name",
+  "effective_status",
+  "campaign{name}",
+  "adset{name}",
+  // `url_tags` é o campo "Parâmetros de URL" do Gerenciador, e `asset_feed_spec`
+  // é onde o criativo dinâmico guarda o destino — sem os dois, anúncio
+  // configurado certo apareceria como se estivesse sem rastreamento.
+  "creative{url_tags,object_story_spec{link_data{link}},asset_feed_spec{link_urls{website_url}}}",
+].join(",");
+
+export async function GET(request: Request) {
+  const { headers, blocked } = guard(request);
+  if (blocked) return blocked;
+
+  const env = getEnv();
+  const token = env.META_ACCESS_TOKEN;
+  const contaBruta = env.META_AD_ACCOUNT_ID;
+
+  if (!token || !contaBruta) {
+    return NextResponse.json(
+      {
+        conclusao: "Credencial da Meta incompleta — sem ela não há o que auditar.",
+        faltando: {
+          META_ACCESS_TOKEN: !token,
+          META_AD_ACCOUNT_ID: !contaBruta,
+        },
+      },
+      { headers },
+    );
+  }
+
+  const conta = contaBruta.startsWith("act_") ? contaBruta : `act_${contaBruta}`;
+  const url = new URL(`https://graph.facebook.com/${env.META_API_VERSION}/${conta}/ads`);
+  url.searchParams.set("fields", CAMPOS);
+  url.searchParams.set("effective_status", JSON.stringify(STATUS));
+  url.searchParams.set("limit", "200");
+
+  try {
+    const anuncios: AnuncioDaMeta[] = [];
+    let proxima: string | null = url.toString();
+
+    // Cinco páginas são mil anúncios — teto de segurança, não de negócio.
+    for (let pagina = 0; pagina < 5 && proxima; pagina++) {
+      const resposta: RespostaDeAnuncios = await httpJson<RespostaDeAnuncios>(proxima, {
+        headers: metaAuthHeaders(token),
+      });
+      anuncios.push(...(resposta.data ?? []));
+      proxima = resposta.paging?.next ?? null;
+    }
+
+    const auditoria = auditarUtms(anuncios);
+
+    return NextResponse.json(
+      {
+        conclusao:
+          auditoria.total === 0
+            ? "Nenhum anúncio ativo ou pausado na conta."
+            : auditoria.completos === auditoria.total
+              ? `Os ${auditoria.total} anúncios carregam as quatro UTMs.`
+              : `${auditoria.total - auditoria.completos} de ${auditoria.total} anúncios estão sem alguma UTM — ${auditoria.semNenhuma} não têm nenhuma.`,
+        // Mais de um valor aqui significa que o mesmo canal chega ao GA4 e ao
+        // CRM sob nomes diferentes, e o relatório se parte em pedaços que
+        // ninguém soma de volta.
+        origensEncontradas: auditoria.origens,
+        resumo: {
+          total: auditoria.total,
+          completos: auditoria.completos,
+          semNenhumaUtm: auditoria.semNenhuma,
+        },
+        anuncios: auditoria.linhas,
+      },
+      { headers },
+    );
+  } catch (erro) {
+    return NextResponse.json(
+      { conclusao: `A Meta não respondeu. Detalhe técnico: ${descreverFalha(erro)}` },
+      { status: 200, headers },
+    );
+  }
+}

--- a/src/server/diagnostico/utm-meta.ts
+++ b/src/server/diagnostico/utm-meta.ts
@@ -30,11 +30,11 @@ export interface AnuncioDaMeta {
 }
 
 /** Os quatro que o painel usa. `utm_term` é opcional e não entra na conta. */
-export const UTMS_ESPERADAS = ["utm_source", "utm_medium", "utm_campaign", "utm_content"] as const;
+const UTMS_ESPERADAS = ["utm_source", "utm_medium", "utm_campaign", "utm_content"] as const;
 
-export type Utm = (typeof UTMS_ESPERADAS)[number];
+type Utm = (typeof UTMS_ESPERADAS)[number];
 
-export interface LinhaDaAuditoria {
+interface LinhaDaAuditoria {
   anuncio: string;
   campanha: string;
   conjunto: string;

--- a/src/server/diagnostico/utm-meta.ts
+++ b/src/server/diagnostico/utm-meta.ts
@@ -1,0 +1,143 @@
+import "server-only";
+
+/**
+ * Auditoria de UTM dos anúncios da Meta.
+ *
+ * Sem UTM, o negócio chega no Kommo sem origem e a tabela "Vendas por origem"
+ * fica em "Sem UTM" — o painel mostra quanto se investiu e quanto se vendeu, mas
+ * não consegue ligar as duas pontas. É a diferença entre saber o custo por lead
+ * e saber o custo por venda.
+ *
+ * Esta leitura é só leitura: ela diz o que falta, e quem corrige é quem tem
+ * acesso de escrita ao Gerenciador. Marcar a URL de um anúncio no ar é mudança
+ * na conta do cliente, não no painel.
+ */
+
+/** O que a Meta devolve por anúncio, no recorte que interessa aqui. */
+export interface AnuncioDaMeta {
+  id: string;
+  name?: string;
+  effective_status?: string;
+  campaign?: { name?: string };
+  adset?: { name?: string };
+  creative?: {
+    /** Parâmetros de rastreamento, o campo "Parâmetros de URL" do Gerenciador. */
+    url_tags?: string;
+    object_story_spec?: { link_data?: { link?: string } };
+    /** Criativo dinâmico guarda os destinos noutro lugar. */
+    asset_feed_spec?: { link_urls?: Array<{ website_url?: string }> };
+  };
+}
+
+/** Os quatro que o painel usa. `utm_term` é opcional e não entra na conta. */
+export const UTMS_ESPERADAS = ["utm_source", "utm_medium", "utm_campaign", "utm_content"] as const;
+
+export type Utm = (typeof UTMS_ESPERADAS)[number];
+
+export interface LinhaDaAuditoria {
+  anuncio: string;
+  campanha: string;
+  conjunto: string;
+  status: string;
+  /** O destino, sem a query — a query vira `presentes`. */
+  destino: string | null;
+  presentes: Utm[];
+  faltando: Utm[];
+  /** Valor de `utm_source`, quando existe: é onde a fragmentação aparece. */
+  origem: string | null;
+}
+
+export interface Auditoria {
+  total: number;
+  completos: number;
+  semNenhuma: number;
+  /** Os valores distintos de `utm_source` encontrados, do mais usado ao menos. */
+  origens: Array<{ valor: string; anuncios: number }>;
+  linhas: LinhaDaAuditoria[];
+}
+
+/**
+ * Os parâmetros que chegam ao site, venham da URL ou do campo de rastreamento.
+ *
+ * A Meta junta os dois: o que está em "Parâmetros de URL" é anexado ao destino
+ * na hora do clique. Olhar só um dos lados reprova anúncio configurado certo —
+ * e é o erro que faz a auditoria virar ruído em vez de lista de tarefas.
+ */
+function parametros(destino: string | undefined, urlTags: string | undefined): Map<string, string> {
+  const mapa = new Map<string, string>();
+
+  const absorver = (busca: string) => {
+    // `URLSearchParams` aceita a string solta do campo de rastreamento, que vem
+    // exatamente no formato `a=1&b=2` — sem `?`.
+    for (const [chave, valor] of new URLSearchParams(busca)) {
+      if (valor.trim() !== "") mapa.set(chave.toLowerCase(), valor);
+    }
+  };
+
+  if (destino) {
+    try {
+      absorver(new URL(destino).search);
+    } catch {
+      // Destino inválido não invalida o resto: o campo de rastreamento pode
+      // estar correto sozinho.
+    }
+  }
+  if (urlTags) absorver(urlTags.replace(/^\?/, ""));
+
+  return mapa;
+}
+
+function semQuery(destino: string | undefined): string | null {
+  if (!destino) return null;
+  try {
+    const url = new URL(destino);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return destino;
+  }
+}
+
+function destinoDoAnuncio(anuncio: AnuncioDaMeta): string | undefined {
+  return (
+    anuncio.creative?.object_story_spec?.link_data?.link ??
+    anuncio.creative?.asset_feed_spec?.link_urls?.[0]?.website_url
+  );
+}
+
+export function auditarUtms(anuncios: AnuncioDaMeta[]): Auditoria {
+  const linhas: LinhaDaAuditoria[] = anuncios.map((anuncio) => {
+    const destino = destinoDoAnuncio(anuncio);
+    const encontrados = parametros(destino, anuncio.creative?.url_tags);
+
+    const presentes = UTMS_ESPERADAS.filter((utm) => encontrados.has(utm));
+    return {
+      anuncio: anuncio.name ?? anuncio.id,
+      campanha: anuncio.campaign?.name ?? "—",
+      conjunto: anuncio.adset?.name ?? "—",
+      status: anuncio.effective_status ?? "—",
+      destino: semQuery(destino),
+      presentes,
+      faltando: UTMS_ESPERADAS.filter((utm) => !encontrados.has(utm)),
+      origem: encontrados.get("utm_source") ?? null,
+    };
+  });
+
+  // Valores distintos de `utm_source`. Mais de um significa que o mesmo canal
+  // chega ao GA4 e ao CRM sob nomes diferentes, e o relatório se parte em
+  // pedaços que ninguém soma de volta.
+  const porOrigem = new Map<string, number>();
+  for (const linha of linhas) {
+    if (!linha.origem) continue;
+    porOrigem.set(linha.origem, (porOrigem.get(linha.origem) ?? 0) + 1);
+  }
+
+  return {
+    total: linhas.length,
+    completos: linhas.filter((l) => l.faltando.length === 0).length,
+    semNenhuma: linhas.filter((l) => l.presentes.length === 0).length,
+    origens: [...porOrigem.entries()]
+      .map(([valor, anuncios]) => ({ valor, anuncios }))
+      .sort((a, b) => b.anuncios - a.anuncios),
+    linhas,
+  };
+}

--- a/tests/unit/utm-meta.test.ts
+++ b/tests/unit/utm-meta.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import { type AnuncioDaMeta, auditarUtms } from "@/server/diagnostico/utm-meta";
+
+/**
+ * Auditoria de UTM da Meta.
+ *
+ * O erro caro aqui não é deixar de achar um problema — é apontar problema onde
+ * não há. Uma lista com anúncios corretos marcados como quebrados faz quem
+ * opera parar de olhar a lista, e aí ela deixa de servir para qualquer coisa.
+ */
+
+const COMPLETA = "utm_source=meta&utm_medium=paid_social&utm_campaign=x&utm_content=y";
+
+function anuncio(parcial: Partial<AnuncioDaMeta> & { id: string }): AnuncioDaMeta {
+  return { name: parcial.id, ...parcial };
+}
+
+function comDestino(id: string, link: string, urlTags?: string): AnuncioDaMeta {
+  return anuncio({
+    id,
+    creative: { url_tags: urlTags, object_story_spec: { link_data: { link } } },
+  });
+}
+
+describe("auditarUtms", () => {
+  it("reconhece UTM que vem na própria URL de destino", () => {
+    const { linhas } = auditarUtms([comDestino("a", `https://qyra.com.br/lp?${COMPLETA}`)]);
+
+    expect(linhas[0].faltando).toEqual([]);
+    expect(linhas[0].origem).toBe("meta");
+  });
+
+  it("reconhece UTM que vem do campo de parâmetros do Gerenciador", () => {
+    const { linhas } = auditarUtms([comDestino("a", "https://qyra.com.br/lp", COMPLETA)]);
+
+    // A Meta anexa o campo de rastreamento ao destino no clique. Olhar só a URL
+    // reprovaria um anúncio configurado certo — e lista com falso alarme é
+    // lista que ninguém lê.
+    expect(linhas[0].faltando).toEqual([]);
+  });
+
+  it("soma os dois lados quando cada um traz uma parte", () => {
+    const { linhas } = auditarUtms([
+      comDestino(
+        "a",
+        "https://qyra.com.br/lp?utm_source=meta&utm_medium=paid_social",
+        "utm_campaign=x&utm_content=y",
+      ),
+    ]);
+
+    expect(linhas[0].faltando).toEqual([]);
+  });
+
+  it("aponta exatamente o que falta, e não só que falta algo", () => {
+    const { linhas } = auditarUtms([
+      comDestino("a", "https://qyra.com.br/lp?utm_source=meta&utm_medium=paid_social"),
+    ]);
+
+    // "Está incompleto" manda alguém abrir o anúncio para descobrir o quê.
+    expect(linhas[0].faltando).toEqual(["utm_campaign", "utm_content"]);
+    expect(linhas[0].presentes).toEqual(["utm_source", "utm_medium"]);
+  });
+
+  it("parâmetro com valor vazio conta como ausente", () => {
+    const { linhas } = auditarUtms([
+      comDestino("a", "https://qyra.com.br/lp?utm_source=&utm_medium=paid_social"),
+    ]);
+
+    // `utm_source=` chega ao GA4 como origem em branco: presente na URL, inútil
+    // no relatório.
+    expect(linhas[0].faltando).toContain("utm_source");
+  });
+
+  it("lê o destino do criativo dinâmico, que guarda a URL noutro lugar", () => {
+    const { linhas } = auditarUtms([
+      anuncio({
+        id: "a",
+        creative: {
+          asset_feed_spec: { link_urls: [{ website_url: `https://qyra.com.br/lp?${COMPLETA}` }] },
+        },
+      }),
+    ]);
+
+    expect(linhas[0].faltando).toEqual([]);
+  });
+
+  it("destino inválido não derruba a leitura do campo de rastreamento", () => {
+    const { linhas } = auditarUtms([comDestino("a", "não é uma url", COMPLETA)]);
+
+    expect(linhas[0].faltando).toEqual([]);
+  });
+
+  it("anúncio sem criativo nenhum aparece como sem UTM, e não some", () => {
+    const { linhas, semNenhuma } = auditarUtms([anuncio({ id: "a" })]);
+
+    expect(linhas).toHaveLength(1);
+    expect(linhas[0].presentes).toEqual([]);
+    expect(semNenhuma).toBe(1);
+  });
+
+  it("lista os valores distintos de origem, do mais usado ao menos", () => {
+    const { origens } = auditarUtms([
+      comDestino("a", "https://q.com/?utm_source=meta"),
+      comDestino("b", "https://q.com/?utm_source=meta"),
+      comDestino("c", "https://q.com/?utm_source=ig"),
+    ]);
+
+    // Mais de um valor significa o mesmo canal chegando ao GA4 e ao CRM sob
+    // nomes diferentes — o relatório se parte em pedaços que ninguém soma.
+    expect(origens).toEqual([
+      { valor: "meta", anuncios: 2 },
+      { valor: "ig", anuncios: 1 },
+    ]);
+  });
+
+  it("conta quantos estão completos e quantos estão zerados", () => {
+    const { total, completos, semNenhuma } = auditarUtms([
+      comDestino("a", `https://q.com/?${COMPLETA}`),
+      comDestino("b", "https://q.com/?utm_source=meta"),
+      comDestino("c", "https://q.com/"),
+    ]);
+
+    expect({ total, completos, semNenhuma }).toEqual({ total: 3, completos: 1, semNenhuma: 1 });
+  });
+
+  it("guarda o destino sem a query, para a tabela ficar legível", () => {
+    const { linhas } = auditarUtms([comDestino("a", `https://qyra.com.br/lp?${COMPLETA}`)]);
+
+    expect(linhas[0].destino).toBe("https://qyra.com.br/lp");
+  });
+});


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — pedido direto: revisar as campanhas de Meta Ads e conferir os
UTMs. Abro a Issue de Nova função referenciando este PR.

## Por que existe

Sem UTM, o negócio chega ao Kommo sem procedência e a tabela **"Vendas por
origem"** acumula tudo em "Sem UTM". O painel sabe quanto se investiu e quanto se
vendeu, mas não liga as duas pontas — é a diferença entre saber o **custo por
lead** e saber o **custo por venda**.

Descobrir quais peças estão sem rastreamento exigia abrir anúncio por anúncio no
Gerenciador. `GET /api/diagnostico/utm` responde de uma vez.

## O que ele faz

Lista todos os anúncios **ativos e pausados** com campanha, conjunto, destino, o
que já tem e o que falta — nomeado. "Está incompleto" só manda alguém abrir o
anúncio para descobrir o quê.

Mais um resumo: quantos estão completos, quantos não têm nenhuma UTM, e os
**valores distintos de `utm_source`** encontrados.

Quatro decisões que valem comentário:

**Lê os dois lados que a Meta junta no clique.** O que está em "Parâmetros de
URL" (`creative.url_tags`) é anexado ao destino na hora do clique. Olhar só a URL
reprovaria anúncio configurado certo — e lista com falso alarme é lista que
ninguém lê. O teste cobre o caso em que cada lado traz metade.

**Cobre o criativo dinâmico**, que guarda o destino em `asset_feed_spec.link_urls`
em vez de `object_story_spec.link_data`. Sem isso, esses anúncios apareceriam
todos como se estivessem sem rastreamento.

**Anúncio pausado entra na conta.** Peça pausada volta a rodar com a configuração
que tinha; auditar só as ativas esconde a dívida até o dia em que alguém reativa
a campanha antiga e o rastreamento some sem ninguém entender por quê.

**Parâmetro com valor vazio conta como ausente.** `utm_source=` chega ao GA4 como
origem em branco: presente na URL, inútil no relatório.

## A fragmentação que isso já revela

No diagnóstico do Google, o GA4 mostra o tráfego da Meta chegando sob **três
nomes**: `meta/paid_social` (109 sessões), `ig/paid_social` (55) e `fb/paid_social`
(8). O mesmo canal partido em três no relatório — por isso o endpoint conta os
`utm_source` distintos, e não só se existe algum.

## Só leitura, de propósito

Corrigir a URL de um anúncio no ar é mudança na conta do cliente. O painel não
tem — nem deve ganhar sem que alguém peça — permissão de escrita na Meta. O
endpoint diz o que falta; quem corrige é quem tem acesso ao Gerenciador.

## Como foi validado

- [x] `npm run verify` — **276 testes** (11 novos), lint, tipos e contrato de arquitetura
- [x] `npm run build` limpo

Os testes cobrem a análise, que é onde mora o risco de falso alarme: UTM só na
URL, só no campo de rastreamento, dividida entre os dois, valor vazio, criativo
dinâmico, destino inválido, anúncio sem criativo, e a contagem de origens
distintas.

Não deu para exercitar contra a conta real: o ambiente onde isto foi escrito não
alcança `graph.facebook.com` e não tem o token, que fica na Vercel.

## Riscos e limitações

**A leitura não prevê macro que a Meta expande no clique.** Um `utm_campaign=
{{campaign.name}}` é contado como presente — que é o certo —, mas o endpoint não
verifica se a macro está escrita corretamente. Macro com erro de digitação chega
ao site literal, e isso só aparece no GA4.

**Teto de cinco páginas** (mil anúncios). É trava de segurança, não limite de
negócio; contas maiores precisariam de paginação declarada na resposta.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_