### PR TITLE
fix: o Comportamento para de dizer "não configurado" com o token cadastrado

### DIFF
--- a/src/app/(painel)/comportamento/page.tsx
+++ b/src/app/(painel)/comportamento/page.tsx
@@ -25,7 +25,7 @@ export const maxDuration = 30;
  * lugar que ninguém rola até.
  */
 export default async function Page() {
-  const resumo = await getClarityResumo();
+  const clarity = await getClarityResumo();
 
   return (
     <div className="space-y-5 sm:space-y-6">
@@ -34,14 +34,25 @@ export default async function Page() {
         description="Até onde as pessoas leem e onde a página não responde — pelo Microsoft Clarity"
       />
 
-      {resumo ? (
-        <ClarityPanel resumo={resumo} />
-      ) : (
+      {clarity.estado === "ok" ? <ClarityPanel resumo={clarity.resumo} /> : null}
+
+      {clarity.estado === "sem-credencial" ? (
         <EmptyState
           title="Clarity não configurado"
           description="Cadastre CLARITY_API_TOKEN e CLARITY_PROJECT_ID para esta tela ler os dados de rolagem e atrito. Sem eles não há o que mostrar."
         />
-      )}
+      ) : null}
+
+      {/* Estado próprio, e não o mesmo "não configurado" de antes. Mandar
+          cadastrar uma variável que já está cadastrada faz quem lê procurar o
+          problema no lugar errado — e o motivo mais provável aqui é a cota
+          diária da API, que é de poucas chamadas e não avisa antes de acabar. */}
+      {clarity.estado === "falhou" ? (
+        <EmptyState
+          title="O Clarity está configurado, mas não respondeu"
+          description={`A credencial está cadastrada — o que falhou foi a consulta. A causa mais comum é a cota diária da API do Clarity, que é de poucas chamadas por dia e se recompõe sozinha no dia seguinte. Detalhe técnico: ${clarity.motivo}`}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -192,6 +192,19 @@ export interface ContentCard {
  * Mora aqui, e não no conector, porque `components/` não pode importar de
  * `server/` — é o contrato de arquitetura cravado na CI.
  */
+/**
+ * O que a tela de Comportamento recebe.
+ *
+ * Três estados, e não "resumo ou nada". A primeira versão devolvia `null` tanto
+ * para "falta credencial" quanto para "a chamada falhou", e a tela imprimia
+ * "Clarity não configurado" nos dois casos — com o token cadastrado e presente
+ * no diagnóstico. Quem lia era mandado configurar o que já estava configurado.
+ */
+export type ClarityEstado =
+  | { estado: "sem-credencial" }
+  | { estado: "falhou"; motivo: string }
+  | { estado: "ok"; resumo: ClarityResumo };
+
 export interface ClarityResumo {
   /** Fração média da página que as pessoas percorreram. Entre 0 e 1. */
   rolagemMedia: number;

--- a/src/server/connectors/clarity.ts
+++ b/src/server/connectors/clarity.ts
@@ -1,9 +1,9 @@
 import "server-only";
 
-import type { ClarityResumo } from "@/lib/types";
+import type { ClarityEstado } from "@/lib/types";
 import { mockClarity } from "@/mocks/reports";
 import { getCredentials, getEnv, isForceMock } from "@/server/env";
-import { httpJson } from "@/server/lib/http";
+import { descreverFalha, httpJson } from "@/server/lib/http";
 
 /**
  * Microsoft Clarity via API de exportação (`project-live-insights`).
@@ -64,6 +64,11 @@ async function buscarInsights(dias: number, dimensao?: string): Promise<ClarityM
     // A cota é diária: repetir uma chamada que falhou queima o que resta.
     retries: 0,
     timeoutMs: 20_000,
+    // Cache compartilhado entre instâncias. O cache em memória do painel é por
+    // instância, e a Vercel sobe várias: cada partida a frio recomeçava com o
+    // cache vazio e gastava mais duas chamadas da cota — que é de poucas por
+    // dia. Meia hora de validade, a mesma do cache em memória.
+    revalidateSeconds: 1_800,
   });
 }
 
@@ -81,15 +86,17 @@ function somar(linhas: ClarityLinha[], campo: string): number {
 /**
  * Fotografia recente do comportamento no site.
  *
- * Devolve `null` quando não há credencial ou a chamada falha: esta seção é
- * complemento, e a tela do Analytics continua inteira sem ela.
+ * **Distingue "não configurado" de "falhou".** Antes os dois voltavam `null`, e
+ * a tela imprimia "Clarity não configurado" mesmo com o token cadastrado — o
+ * caso mais provável aqui, porque a cota da API é de poucas chamadas por dia e
+ * estourar a cota é uma falha como qualquer outra.
  */
-export async function fetchClarityResumo(): Promise<ClarityResumo | null> {
+export async function fetchClarityResumo(): Promise<ClarityEstado> {
   const env = getEnv();
   // Em demonstração a seção aparece com números fictícios, como o resto da
   // tela — sumir dela deixaria a demonstração incompleta.
-  if (isForceMock()) return mockClarity();
-  if (!getCredentials().clarity) return null;
+  if (isForceMock()) return { estado: "ok", resumo: mockClarity() };
+  if (!getCredentials().clarity) return { estado: "sem-credencial" };
 
   try {
     const [geral, porUrl] = await Promise.all([
@@ -110,7 +117,7 @@ export async function fetchClarityResumo(): Promise<ClarityResumo | null> {
     const atritoPorPagina = (nome: string) =>
       new Map(metrica(porUrl, nome).map((l) => [String(l.URL ?? ""), num(l.subTotal)]));
 
-    return {
+    const resumo = {
       // A API devolve a profundidade em porcentagem (0-100); a tela trabalha
       // em fração, como todo percentual do painel.
       rolagemMedia: rolagem.length === 0 ? 0 : num(rolagem[0]?.averageScrollDepth) / 100,
@@ -136,9 +143,12 @@ export async function fetchClarityResumo(): Promise<ClarityResumo | null> {
       dias: MAX_DIAS,
       projeto: env.CLARITY_PROJECT_ID ?? null,
     };
-  } catch {
-    // Cota estourada, token inválido ou instabilidade: a tela do Analytics não
-    // pode cair por causa de uma seção complementar.
-    return null;
+
+    return { estado: "ok", resumo };
+  } catch (erro) {
+    // Cota estourada, token inválido ou instabilidade. A tela não cai por causa
+    // disso — mas passa a dizer o que aconteceu, em vez de mandar configurar o
+    // que já está configurado.
+    return { estado: "falhou", motivo: descreverFalha(erro) };
   }
 }

--- a/src/server/lib/http.ts
+++ b/src/server/lib/http.ts
@@ -12,6 +12,11 @@ export interface HttpOptions extends Omit<RequestInit, "signal"> {
   timeoutMs?: number;
   /** Tentativas extras em 429/5xx/rede. */
   retries?: number;
+  /**
+   * Guarda a resposta no Data Cache do Next por N segundos, compartilhado entre
+   * instâncias. Só para API com cota diária baixa — ver o comentário no `fetch`.
+   */
+  revalidateSeconds?: number;
 }
 
 export class HttpError extends Error {
@@ -76,7 +81,7 @@ function backoffMs(attempt: number): number {
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 export async function httpJson<T>(url: string, options: HttpOptions = {}): Promise<T> {
-  const { timeoutMs = 15_000, retries = 2, headers, ...init } = options;
+  const { timeoutMs = 15_000, retries = 2, headers, revalidateSeconds, ...init } = options;
   let lastError: unknown;
 
   for (let attempt = 0; attempt <= retries; attempt++) {
@@ -88,7 +93,17 @@ export async function httpJson<T>(url: string, options: HttpOptions = {}): Promi
         ...init,
         headers: { accept: "application/json", ...headers },
         signal: controller.signal,
-        cache: "no-store",
+        // `no-store` por padrão: relatório servido de cache silencioso é a
+        // forma mais fácil de mostrar número velho numa reunião.
+        //
+        // A exceção é API de cota diária baixa. O cache em memória do painel é
+        // **por instância**, e a Vercel sobe várias — cada partida a frio
+        // recomeça com o cache vazio e gasta mais uma chamada da cota. O Data
+        // Cache do Next é compartilhado entre instâncias, e é o único que
+        // segura uma cota de poucas chamadas por dia.
+        ...(revalidateSeconds === undefined
+          ? { cache: "no-store" as const }
+          : { next: { revalidate: revalidateSeconds } }),
       });
 
       if (!response.ok) {

--- a/src/server/reports.ts
+++ b/src/server/reports.ts
@@ -6,7 +6,7 @@ import { previousRange } from "@/lib/date-range";
 import type {
   ChannelId,
   ChannelReport,
-  ClarityResumo,
+  ClarityEstado,
   DataSource,
   DateRange,
   Kpi,
@@ -38,7 +38,7 @@ import { fetchOrganicoReport } from "./connectors/organico";
  */
 const TTL_CLARITY_SEGUNDOS = 1_800;
 
-export function getClarityResumo(): Promise<ClarityResumo | null> {
+export function getClarityResumo(): Promise<ClarityEstado> {
   return cached("clarity:resumo", fetchClarityResumo, TTL_CLARITY_SEGUNDOS);
 }
 

--- a/tests/integration/clarity.test.ts
+++ b/tests/integration/clarity.test.ts
@@ -43,9 +43,16 @@ function respostaPorUrl() {
   ];
 }
 
-async function resumo() {
+async function estado() {
   const { fetchClarityResumo } = await import("@/server/connectors/clarity");
   return fetchClarityResumo();
+}
+
+/** O resumo, quando há um. Falha o teste se o estado não for `ok`. */
+async function resumo() {
+  const atual = await estado();
+  if (atual.estado !== "ok") throw new Error(`esperava resumo, veio ${atual.estado}`);
+  return atual.resumo;
 }
 
 beforeEach(() => {
@@ -80,8 +87,8 @@ describe("Clarity", () => {
 
     // A API devolve 57.4; a tela formata percentual a partir de fração. Sem a
     // divisão, "57,4%" viraria "5740%".
-    expect(r?.rolagemMedia).toBeCloseTo(0.574, 4);
-    expect(r?.porPagina.find((p) => p.pagina === "/planos")?.rolagem).toBeCloseTo(0.382, 4);
+    expect(r.rolagemMedia).toBeCloseTo(0.574, 4);
+    expect(r.porPagina.find((p) => p.pagina === "/planos")?.rolagem).toBeCloseTo(0.382, 4);
   });
 
   it("ordena as páginas por sessões, não pela ordem da API", async () => {
@@ -102,27 +109,54 @@ describe("Clarity", () => {
 
     // A página com mais gente é a que interessa primeiro; a API devolve
     // /planos antes só porque sim.
-    expect(r?.porPagina.map((p) => p.pagina)).toEqual(["/", "/planos"]);
+    expect(r.porPagina.map((p) => p.pagina)).toEqual(["/", "/planos"]);
   });
 
-  it("sem token, devolve nulo em vez de tentar a chamada", async () => {
+  it("sem token, diz que falta credencial em vez de tentar a chamada", async () => {
     const espiao = vi.fn();
     vi.stubGlobal("fetch", espiao);
 
-    expect(await resumo()).toBeNull();
+    expect(await estado()).toEqual({ estado: "sem-credencial" });
     expect(espiao).not.toHaveBeenCalled();
   });
 
-  it("falha da API não derruba a tela — devolve nulo", async () => {
+  it("cota estourada não vira 'não configurado'", async () => {
     for (const [k, v] of Object.entries(CREDENCIAIS)) vi.stubEnv(k, v);
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response("quota exceeded", { status: 429, statusText: "Too Many" })),
     );
 
-    // A seção é complemento do Analytics. Estourar a cota não pode custar a
-    // tela inteira.
-    expect(await resumo()).toBeNull();
+    const atual = await estado();
+
+    // Com o token cadastrado, "não configurado" manda quem lê procurar o
+    // problema no lugar errado — e a cota é justamente a causa mais provável
+    // aqui, porque a API dá poucas chamadas por dia e não avisa antes de acabar.
+    expect(atual.estado).toBe("falhou");
+    if (atual.estado === "falhou") expect(atual.motivo).toMatch(/429/);
+  });
+
+  it("guarda a resposta no cache compartilhado, por causa da cota diária", async () => {
+    for (const [k, v] of Object.entries(CREDENCIAIS)) vi.stubEnv(k, v);
+    const espiao = vi.fn(
+      async () =>
+        new Response(JSON.stringify(respostaDoClarity()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", espiao);
+
+    await estado();
+
+    // O cache em memória do painel é por instância, e a Vercel sobe várias:
+    // cada partida a frio gastava mais duas chamadas de uma cota que é de
+    // poucas por dia. `next.revalidate` é compartilhado entre instâncias.
+    for (const chamada of espiao.mock.calls as unknown as Array<[string, RequestInit]>) {
+      const init = chamada[1] as RequestInit & { next?: { revalidate?: number } };
+      expect(init.next?.revalidate).toBeGreaterThan(0);
+      expect(init.cache).toBeUndefined();
+    }
   });
 
   it("não repete chamada que falhou — a cota é diária", async () => {
@@ -132,7 +166,7 @@ describe("Clarity", () => {
     );
     vi.stubGlobal("fetch", espiao);
 
-    await resumo();
+    await estado();
 
     // Duas chamadas (geral e por URL), nenhuma retentativa. Com retry, um erro
     // transitório queimaria o que resta da cota do dia.
@@ -150,7 +184,7 @@ describe("Clarity", () => {
     );
     vi.stubGlobal("fetch", espiao);
 
-    await resumo();
+    await estado();
 
     for (const chamada of espiao.mock.calls as unknown as Array<[RequestInfo | URL]>) {
       expect(String(chamada[0])).not.toContain("tok");


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — reportado com print da tela. Abro a Issue de Correção
referenciando este PR.

## O defeito

A tela de Comportamento mandava cadastrar `CLARITY_API_TOKEN` e
`CLARITY_PROJECT_ID` **enquanto os dois estavam presentes** — o `/api/health` da
produção lista as duas variáveis e reporta `clarity: true`.

Quem lia era mandado resolver o que já estava resolvido, e procurava o problema
no lugar errado.

## Duas causas, uma em cima da outra

### 1. O conector não distinguia "não configurado" de "falhou"

`fetchClarityResumo` devolvia `null` nos dois casos, e a tela só sabia imprimir a
primeira leitura. Cota estourada, token expirado e instabilidade da API viravam
todos "Clarity não configurado".

Agora devolve estado — `sem-credencial`, `falhou` (com o motivo) ou o resumo — e
a tela tem uma mensagem para cada.

### 2. O cache que protegia a cota é por instância

A API do Clarity dá **poucas chamadas por dia**, e o conector faz duas por
atualização (geral e por URL). A proteção era o cache em memória do painel, com
30 minutos de validade.

Só que esse cache é **por instância**, e a Vercel sobe várias. Cada partida a
frio recomeça com o cache vazio e gasta mais duas chamadas. Meia dúzia de
instâncias novas num dia zeram a cota — e a partir daí **toda** consulta falha,
o dia inteiro.

`httpJson` ganha `revalidateSeconds`, que troca o `cache: "no-store"` pelo Data
Cache do Next, compartilhado entre instâncias. Só o Clarity usa: nos demais
conectores, cache silencioso é exatamente como se mostra número velho numa
reunião.

## Como foi validado

- [x] `npm run verify` — **267 testes**, lint, tipos e contrato de arquitetura
- [x] `npm run test:e2e` — 46/46
- [x] `npm run build` limpo

Testes novos: sem token devolve `sem-credencial` sem tocar na rede; cota
estourada devolve `falhou` com o `429` no motivo, e **não** `sem-credencial`; e
as chamadas do Clarity saem com `next.revalidate`, sem `cache: "no-store"`.

## Riscos e limitações

**Meia hora de validade no cache compartilhado** significa que um dado do
Clarity pode ficar até 30 minutos velho. É a mesma janela do cache em memória
que já existia — a diferença é que agora ela vale de verdade, entre instâncias.

**Não sabemos ainda qual é a falha real em produção.** O código agora mostra o
motivo na tela; a hipótese da cota é a mais provável pelo desenho, mas quem
confirma é a mensagem que aparecer no próximo carregamento.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_