### PR TITLE
fix: tira o aviso do leilão da tela e escreve a regra que faltava

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,25 @@ recuperação, e funcionamento em tema claro e escuro.
 
 ---
 
+## 5.1 Texto que aparece na tela
+
+**Nenhuma mensagem nova chega à tela do painel sem aprovação de quem opera.**
+Vale para aviso em faixa, estado vazio, rótulo de selo e qualquer texto que o
+cliente leia — não só para os que explicam erro.
+
+A tela é apresentada a clientes e à diretoria. Quem decide o que aparece ali é
+quem apresenta, não quem escreve o conector. Um aviso explicando uma limitação
+da API do Google Ads foi publicado por conta própria e teve de ser removido
+depois de já estar no ar.
+
+Limitação técnica, motivo de um número faltar, detalhe de integração: registre
+em comentário no código e em `docs/integracoes.md`. O diagnóstico
+(`/api/diagnostico/*`, `/api/health`) é o lugar de encanamento — ele já é
+restrito a quem opera. Só vira texto na tela quando alguém pedir.
+
+Em código, isso é a diferença entre `avisoOperacao` (não vai para a tela) e
+`avisoCliente` (vai). Toda chamada nova a `avisoCliente` precisa de aprovação.
+
 ## 6. Segurança e operação
 
 - Segredo só em `src/server/**`, que importa `server-only`. Se um módulo de

--- a/docs/integracoes.md
+++ b/docs/integracoes.md
@@ -130,6 +130,17 @@ GOOGLE_ADS_API_VERSION=                      # opcional, ver abaixo
 
 Os hífens são removidos pelo conector — pode colar como aparece na interface.
 
+### O que a API não entrega
+
+**Informações de leilão.** O relatório que mostra quem mais aparece nas mesmas
+buscas não existe na API do Google Ads — nem por GAQL nem por recurso próprio.
+Consultas a `auction_insight_*` respondem `BAD_RESOURCE_TYPE_IN_FROM_CLAUSE`, e
+o programa de acesso por lista está fechado para novas contas. É dado exclusivo
+da interface: Insights → Relatórios → Informações do leilão.
+
+Não há aviso disso na tela, por decisão de quem opera — a limitação fica
+registrada aqui.
+
 ### O token de desenvolvedor
 
 O token nasce com acesso *Test* e só lê contas de teste. Para ler a conta de

--- a/src/lib/avisos.ts
+++ b/src/lib/avisos.ts
@@ -2,8 +2,15 @@ import type { Notice } from "./types";
 
 /**
  * Aviso que ajuda a ler o relatório: por que um canal está fora do
- * consolidado, por que o filtro de data não move um período fixo. Vai para a
- * tela.
+ * consolidado, por que um número não pode ser comparado. Vai para a tela.
+ *
+ * **Texto novo aqui precisa de aprovação de quem opera o painel.** A tela é
+ * lida pelo cliente, e o que aparece nela é decisão de quem apresenta — não do
+ * conector. Um aviso explicando limitação de API foi publicado sem passar por
+ * essa porta e teve de ser removido depois de já estar no ar.
+ *
+ * Limitação técnica se registra em comentário e em `docs/integracoes.md`. Só
+ * vira aviso na tela quando alguém pedir.
  */
 export function avisoCliente(text: string): Notice {
   return { text, audience: "cliente" };

--- a/src/server/connectors/google-ads.ts
+++ b/src/server/connectors/google-ads.ts
@@ -1,4 +1,4 @@
-import { avisoCliente, avisoOperacao } from "@/lib/avisos";
+import { avisoOperacao } from "@/lib/avisos";
 import "server-only";
 
 import { eachDay } from "@/lib/date-range";
@@ -502,14 +502,12 @@ export async function fetchGoogleAdsReport(range: DateRange): Promise<ChannelRep
         rows: locais.visiveis,
       },
     ],
-    // Informações de leilão não entram: o Google não expõe esse relatório na
-    // API, nem por GAQL nem por recurso próprio — é dado exclusivo da
-    // interface. Fingir que existe seria inventar; omitir sem dizer deixaria
-    // quem procura achando que o painel esqueceu.
-    notices: [
-      avisoCliente(
-        "O relatório de informações do leilão — quem mais aparece nas mesmas buscas — não está no painel porque o Google não o disponibiliza por API. Ele existe apenas na interface do Google Ads, em Insights → Relatórios → Informações do leilão.",
-      ),
-    ],
+    // Informações de leilão não entram: o Google não expõe esse relatório na API,
+    // nem por GAQL nem por recurso próprio — é dado exclusivo da interface.
+    //
+    // Houve um aviso na tela explicando isso, e ele saiu a pedido: a tela é do
+    // cliente, e o que aparece nela é decisão de quem opera, não do conector.
+    // A limitação fica registrada aqui e em `docs/integracoes.md`.
+    notices: [],
   };
 }

--- a/tests/integration/connectors.test.ts
+++ b/tests/integration/connectors.test.ts
@@ -356,29 +356,6 @@ describe("Google Ads", () => {
     ]);
   });
 
-  it("diz que o leilão não vem por API, em vez de omitir em silêncio", async () => {
-    await withCredentials({
-      ...GOOGLE_OAUTH,
-      GOOGLE_ADS_DEVELOPER_TOKEN: "dev",
-      GOOGLE_ADS_CUSTOMER_ID: "123-456-7890",
-    });
-    mockFetch((url) => {
-      if (url.includes("oauth2.googleapis.com")) return TOKEN_RESPONSE;
-      if (url.includes("searchStream")) return [{ results: [] }];
-      return {};
-    });
-
-    const { fetchGoogleAdsReport } = await import("@/server/connectors/google-ads");
-    const report = await fetchGoogleAdsReport(RANGE);
-
-    // A oitava tabela do export não tem equivalente na API — é dado exclusivo
-    // da interface. Omitir sem dizer deixaria quem procura achando que o painel
-    // esqueceu.
-    const aviso = report.notices.find((n) => /leilão/i.test(n.text));
-    expect(aviso).toBeTruthy();
-    expect(aviso?.audience).toBe("cliente");
-  });
-
   it("envia developer-token e login-customer-id sem hífen", async () => {
     await withCredentials({
       ...GOOGLE_OAUTH,


### PR DESCRIPTION
## Issue relacionada

Sem Issue prévia — pedido direto de quem opera o painel. Abro a Issue de
Correção referenciando este PR.

## O que aconteceu

Ao trazer o Google Ads ao vivo, publiquei um aviso na tela explicando que
informações de leilão não vêm por API. Ninguém pediu esse texto, e ele foi ao ar
na tela que o cliente e a diretoria leem.

Sai da tela.

## A regra que faltava

A fronteira já existia no código — `avisoOperacao` não vai para a tela,
`avisoCliente` vai. O que faltava era dizer que **atravessá-la depende de
aprovação**, não do julgamento de quem está escrevendo o conector.

Fica escrita em dois lugares: uma seção nova no `AGENTS.md` e o comentário do
próprio `avisoCliente`, que é onde alguém esbarra nela ao escrever a próxima.

Vale para **qualquer texto que o cliente leia** — faixa de aviso, estado vazio,
rótulo de selo —, não só para os que explicam erro.

Onde a informação vai, então:

| O quê | Onde |
|---|---|
| Limitação técnica, motivo de um número faltar | Comentário no código e `docs/integracoes.md` |
| Estado de credencial, erro de API, encanamento | `/api/health` e `/api/diagnostico/*`, já restritos a quem opera |
| Texto na tela | Só quando alguém pedir |

A limitação do leilão agora está em `docs/integracoes.md`, com o detalhe de por
que a API não a entrega: consultas a `auction_insight_*` respondem
`BAD_RESOURCE_TYPE_IN_FROM_CLAUSE`, e o programa de acesso por lista está
fechado para novas contas.

## Como foi validado

- [x] `npm run verify` — **273 testes**, lint, tipos e contrato de arquitetura
- [x] `npm run test:e2e` — 46/46
- [x] `npm run build` limpo

O teste que cobrava a existência do aviso saiu junto — ele travava exatamente o
comportamento que estava errado.

## Riscos e limitações

**A regra é de processo, não de código.** Nada na CI impede uma chamada nova a
`avisoCliente`. Dá para travar com uma regra de lint por lista de exceções, mas
seria cerca alta demais para o tamanho do problema — o comentário fica no
caminho de quem for escrever a próxima.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgqcv9wKFscT9bAGSSnw99)_